### PR TITLE
Add fargate public network and log-puller stacks

### DIFF
--- a/api.concordqa.org.yml
+++ b/api.concordqa.org.yml
@@ -1,0 +1,30 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: Creates api.concordqa.org API gateway domain and Route53 alias
+
+Resources:
+
+  ApiGatewayDomain:
+    Type: AWS::ApiGateway::DomainName
+    Properties:
+      CertificateArn: arn:aws:acm:us-east-1:816253370536:certificate/7b8bb00e-7aa4-4b9f-a722-f49c828af83c
+      DomainName: api.concordqa.org
+
+  ApiGatewayDNSRecord:
+    DependsOn: ApiGatewayDomain
+    Type: AWS::Route53::RecordSet
+    Properties:
+      HostedZoneId: Z270F8MK5GG1RH  # concordqa.org
+      Name: api.concordqa.org.
+      Type: A
+      AliasTarget:
+        DNSName: !GetAtt ApiGatewayDomain.DistributionDomainName
+        EvaluateTargetHealth: no  # this can't be used with CloudFront distribution aliases
+        HostedZoneId: !GetAtt ApiGatewayDomain.DistributionHostedZoneId
+
+Outputs:
+  ApiDomainName:
+    Description: Api domain name
+    Value: !Ref ApiGatewayDomain
+  ApiDistributionDomainName:
+    Description: Api distribution domain name
+    Value: !GetAtt ApiGatewayDomain.DistributionDomainName

--- a/fargate/log-puller.yml
+++ b/fargate/log-puller.yml
@@ -8,6 +8,11 @@ Parameters:
     Default: fargate-public-network
     Description: The name of the parent Fargate networking stack that you created. Necessary
                  to locate and reference resources created by that stack.
+  LogIngesterStackName:
+    Type: String
+    Description: The name of the log ingester stack
+    Default: log-ingester-staging
+    AllowedValues: [log-ingester, log-ingester-staging]
   ServiceName:
     Type: String
     Default: log-puller
@@ -110,6 +115,7 @@ Resources:
           SecurityGroups:
             - Fn::ImportValue:
                 !Join [':', [!Ref 'StackName', 'FargateContainerSecurityGroup']]
+            - !Ref ServiceSecurityGroup
           Subnets:
             - Fn::ImportValue:
                 !Join [':', [!Ref 'StackName', 'PublicSubnetOne']]
@@ -120,6 +126,26 @@ Resources:
         - ContainerName: !Ref 'ServiceName'
           ContainerPort: !Ref 'ContainerPort'
           TargetGroupArn: !Ref 'TargetGroup'
+
+  ServiceSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Log puller ECS service security group
+      VpcId:
+        Fn::ImportValue:
+          !Join [':', [!Ref 'StackName', 'VPCId']]
+
+  ServiceDBIngress:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      Description: Adds ECS service to RDS security group
+      GroupId:
+        Fn::ImportValue:
+          !Join [':', [!Ref 'LogIngesterStackName', 'RdsSecurityGroup']]
+      IpProtocol: tcp
+      FromPort: 5432
+      ToPort: 5432
+      SourceSecurityGroupId: !Ref ServiceSecurityGroup
 
   # A target group. This is used for keeping track of all the tasks, and
   # what IP addresses / port numbers they have. You can query it yourself,

--- a/fargate/log-puller.yml
+++ b/fargate/log-puller.yml
@@ -1,0 +1,173 @@
+# adapted from https://github.com/nathanpeck/aws-cloudformation-fargate/
+
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Deploy log-puller on AWS Fargate, hosted in a public subnet, and accessible via a public load balancer.
+Parameters:
+  StackName:
+    Type: String
+    Default: fargate-public-network
+    Description: The name of the parent Fargate networking stack that you created. Necessary
+                 to locate and reference resources created by that stack.
+  ServiceName:
+    Type: String
+    Default: log-puller
+    Description: A name for the service
+  ImageUrl:
+    Type: String
+    Default: concordconsortium/log-puller
+    Description: The url of a docker image that contains the application process that
+                 will handle the traffic for this service
+  ContainerPort:
+    Type: Number
+    Default: 5000
+    Description: What port number the application inside the docker container is binding to
+  ContainerCpu:
+    Type: Number
+    Default: 256
+    Description: How much CPU to give the container. 1024 is 1 CPU
+  ContainerMemory:
+    Type: Number
+    Default: 512
+    Description: How much memory in megabytes to give the container
+  Path:
+    Type: String
+    Default: "/log-puller*"
+    Description: A path on the public load balancer that this service
+                 should be connected to. This should NOT be *.
+  Priority:
+    Type: Number
+    Default: 1
+    Description: The priority for the routing rule added to the load balancer.
+                 This only applies if your have multiple services which have been
+                 assigned to different paths on the load balancer.
+  DesiredCount:
+    Type: Number
+    Default: 2
+    Description: How many copies of the service task to run
+  RdsDatabaseUrl:
+    Type: String
+    Description: Url to RDS instance, in format postgres://USERNAME:PASSWORD@HOSTNAME/DATABASE
+  JwtHmacSecret:
+    Type: String
+    Description: Shared HMAC secret with portal
+
+Resources:
+
+  # The task definition. This is a simple metadata description of what
+  # container to run, and what resource requirements it has.
+  TaskDefinition:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      Family: !Ref 'ServiceName'
+      Cpu: !Ref 'ContainerCpu'
+      Memory: !Ref 'ContainerMemory'
+      NetworkMode: awsvpc
+      RequiresCompatibilities:
+        - FARGATE
+      ExecutionRoleArn:
+        Fn::ImportValue:
+          !Join [':', [!Ref 'StackName', 'ECSTaskExecutionRole']]
+      ContainerDefinitions:
+        - Name: !Ref 'ServiceName'
+          Cpu: !Ref 'ContainerCpu'
+          Memory: !Ref 'ContainerMemory'
+          Image: !Ref 'ImageUrl'
+          PortMappings:
+            - ContainerPort: !Ref 'ContainerPort'
+          Environment:
+            - Name: RDS_DATABASE_URL
+              Value: !Ref RdsDatabaseUrl
+            - Name: JWT_HMAC_SECRET
+              Value: !Ref JwtHmacSecret
+            - Name: PGSSLROOTCERT
+              Value: rds-combined-ca-bundle.pem
+            - Name: PGSSLMODE
+              Value: verify-full
+            - Name: HEROKU
+              Value: false
+
+  # The service. The service is a resource which allows you to run multiple
+  # copies of a type of task, and gather up their logs and metrics, as well
+  # as monitor the number of running tasks and replace any that have crashed
+  Service:
+    Type: AWS::ECS::Service
+    DependsOn:
+      - LoadBalancerRule80
+      - LoadBalancerRule443
+    Properties:
+      ServiceName: !Ref 'ServiceName'
+      Cluster:
+        Fn::ImportValue:
+          !Join [':', [!Ref 'StackName', 'ClusterName']]
+      LaunchType: FARGATE
+      DeploymentConfiguration:
+        MaximumPercent: 200
+        MinimumHealthyPercent: 75
+      DesiredCount: !Ref 'DesiredCount'
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          AssignPublicIp: ENABLED
+          SecurityGroups:
+            - Fn::ImportValue:
+                !Join [':', [!Ref 'StackName', 'FargateContainerSecurityGroup']]
+          Subnets:
+            - Fn::ImportValue:
+                !Join [':', [!Ref 'StackName', 'PublicSubnetOne']]
+            - Fn::ImportValue:
+                !Join [':', [!Ref 'StackName', 'PublicSubnetTwo']]
+      TaskDefinition: !Ref 'TaskDefinition'
+      LoadBalancers:
+        - ContainerName: !Ref 'ServiceName'
+          ContainerPort: !Ref 'ContainerPort'
+          TargetGroupArn: !Ref 'TargetGroup'
+
+  # A target group. This is used for keeping track of all the tasks, and
+  # what IP addresses / port numbers they have. You can query it yourself,
+  # to use the addresses yourself, but most often this target group is just
+  # connected to an application load balancer, or network load balancer, so
+  # it can automatically distribute traffic across all the targets.
+  TargetGroup:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      HealthCheckIntervalSeconds: 6
+      HealthCheckPath: /
+      HealthCheckProtocol: HTTP
+      HealthCheckTimeoutSeconds: 5
+      HealthyThresholdCount: 2
+      TargetType: ip
+      Name: !Ref 'ServiceName'
+      Port: !Ref 'ContainerPort'
+      Protocol: HTTP
+      UnhealthyThresholdCount: 2
+      VpcId:
+        Fn::ImportValue:
+          !Join [':', [!Ref 'StackName', 'VPCId']]
+
+  LoadBalancerRule80:
+    Type: AWS::ElasticLoadBalancingV2::ListenerRule
+    Properties:
+      Actions:
+        - TargetGroupArn: !Ref 'TargetGroup'
+          Type: 'forward'
+      Conditions:
+        - Field: path-pattern
+          Values: [!Ref 'Path']
+      ListenerArn:
+        Fn::ImportValue:
+          !Join [':', [!Ref 'StackName', 'PublicListener80']]
+      Priority: !Ref 'Priority'
+  LoadBalancerRule443:
+    Type: AWS::ElasticLoadBalancingV2::ListenerRule
+    Properties:
+      Actions:
+        - TargetGroupArn: !Ref 'TargetGroup'
+          Type: 'forward'
+      Conditions:
+        - Field: path-pattern
+          Values: [!Ref 'Path']
+      ListenerArn:
+        Fn::ImportValue:
+          !Join [':', [!Ref 'StackName', 'PublicListener443']]
+      Priority: !Ref 'Priority'
+
+

--- a/fargate/public-network-stack.yml
+++ b/fargate/public-network-stack.yml
@@ -1,0 +1,349 @@
+# adapted from https://github.com/nathanpeck/aws-cloudformation-fargate/
+
+AWSTemplateFormatVersion: '2010-09-09'
+Parameters:
+  ClusterName:
+    Type: String
+    Default: fargate-public-cluster
+    Description: The name of the Fargate networking cluster.
+  SSLCertificateName:
+    Type: String
+    AllowedValues: [star.concord.org, star.staging.concord.org, star.concordqa.org]
+    Description: Certificates registered with AWS. Choose which one to use for the
+      load balancer
+  HostedZoneName:
+    Type: String
+    Default: concord.org
+    Description: The domain used to add the Route53 DNS record
+  Subdomain:
+    Type: String
+    Default: apps
+    Description: The sub-domain to add to Route53 DNS record
+Mappings:
+  SSLCertificateMap:
+    star.concord.org:
+      Id: arn:aws:acm:us-east-1:612297603577:certificate/2b62511e-ccc8-434b-ba6c-a8c33bbd509e
+    star.staging.concord.org:
+      Id: arn:aws:acm:us-east-1:612297603577:certificate/8297f3b1-eb86-4f91-8035-3fbd2c9f5560
+    star.concordqa.org:
+      Id: arn:aws:acm:us-east-1:816253370536:certificate/7b8bb00e-7aa4-4b9f-a722-f49c828af83c
+  # Hard values for the subnet masks. These masks define
+  # the range of internal IP addresses that can be assigned.
+  # The VPC can have all IP's from 10.0.0.0 to 10.0.255.255
+  # There are two subnets which cover the ranges:
+  #
+  # 10.0.0.0 - 10.0.0.255
+  # 10.0.1.0 - 10.0.1.255
+  #
+  # If you need more IP addresses (perhaps you have so many
+  # instances that you run out) then you can customize these
+  # ranges to add more
+  SubnetConfig:
+    VPC:
+      CIDR: '10.0.0.0/16'
+    PublicOne:
+      CIDR: '10.0.0.0/24'
+    PublicTwo:
+      CIDR: '10.0.1.0/24'
+Resources:
+  # VPC in which containers will be networked.
+  # It has two public subnets
+  # We distribute the subnets across the first two available subnets
+  # for the region, for high availability.
+  VPC:
+    Type: AWS::EC2::VPC
+    Properties:
+      EnableDnsSupport: true
+      EnableDnsHostnames: true
+      CidrBlock: !FindInMap ['SubnetConfig', 'VPC', 'CIDR']
+
+  # Two public subnets, where containers can have public IP addresses
+  PublicSubnetOne:
+    Type: AWS::EC2::Subnet
+    Properties:
+      AvailabilityZone:
+         Fn::Select:
+         - 0
+         - Fn::GetAZs: {Ref: 'AWS::Region'}
+      VpcId: !Ref 'VPC'
+      CidrBlock: !FindInMap ['SubnetConfig', 'PublicOne', 'CIDR']
+      MapPublicIpOnLaunch: true
+  PublicSubnetTwo:
+    Type: AWS::EC2::Subnet
+    Properties:
+      AvailabilityZone:
+         Fn::Select:
+         - 1
+         - Fn::GetAZs: {Ref: 'AWS::Region'}
+      VpcId: !Ref 'VPC'
+      CidrBlock: !FindInMap ['SubnetConfig', 'PublicTwo', 'CIDR']
+      MapPublicIpOnLaunch: true
+
+  # Setup networking resources for the public subnets. Containers
+  # in the public subnets have public IP addresses and the routing table
+  # sends network traffic via the internet gateway.
+  InternetGateway:
+    Type: AWS::EC2::InternetGateway
+  GatewayAttachement:
+    Type: AWS::EC2::VPCGatewayAttachment
+    Properties:
+      VpcId: !Ref 'VPC'
+      InternetGatewayId: !Ref 'InternetGateway'
+  PublicRouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref 'VPC'
+  PublicRoute:
+    Type: AWS::EC2::Route
+    DependsOn: GatewayAttachement
+    Properties:
+      RouteTableId: !Ref 'PublicRouteTable'
+      DestinationCidrBlock: '0.0.0.0/0'
+      GatewayId: !Ref 'InternetGateway'
+  PublicSubnetOneRouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref PublicSubnetOne
+      RouteTableId: !Ref PublicRouteTable
+  PublicSubnetTwoRouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref PublicSubnetTwo
+      RouteTableId: !Ref PublicRouteTable
+
+  # ECS Resources
+  ECSCluster:
+    Type: AWS::ECS::Cluster
+    Properties:
+      ClusterName:  !Ref 'ClusterName'
+
+  # A security group for the containers we will run in Fargate.
+  # Two rules, allowing network traffic from a public facing load
+  # balancer and from other members of the security group.
+  #
+  # Remove any of the following ingress rules that are not needed.
+  # If you want to make direct requests to a container using its
+  # public IP address you'll need to add a security group rule
+  # to allow traffic from all IP addresses.
+  FargateContainerSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Access to the Fargate containers
+      VpcId: !Ref 'VPC'
+  EcsSecurityGroupIngressFromPublicALB:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      Description: Ingress from the public ALB
+      GroupId: !Ref 'FargateContainerSecurityGroup'
+      IpProtocol: -1
+      SourceSecurityGroupId: !Ref 'PublicLoadBalancerSG'
+  EcsSecurityGroupIngressFromSelf:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      Description: Ingress from other containers in the same security group
+      GroupId: !Ref 'FargateContainerSecurityGroup'
+      IpProtocol: -1
+      SourceSecurityGroupId: !Ref 'FargateContainerSecurityGroup'
+
+  # Load balancers for getting traffic to containers.
+  # This sample template creates one load balancer:
+  #
+  # - One public load balancer, hosted in public subnets that is accessible
+  #   to the public, and is intended to route traffic to one or more public
+  #   facing services.
+
+  # A public facing load balancer, this is used for accepting traffic from the public
+  # internet and directing it to public facing microservices
+  PublicLoadBalancerSG:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Access to the public facing load balancer
+      VpcId: !Ref 'VPC'
+      SecurityGroupIngress:
+          # Allow access to ALB from anywhere on the internet
+          - CidrIp: 0.0.0.0/0
+            IpProtocol: -1
+  PublicLoadBalancer:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Properties:
+      Scheme: internet-facing
+      LoadBalancerAttributes:
+      - Key: idle_timeout.timeout_seconds
+        Value: '30'
+      Subnets:
+        # The load balancer is placed into the public subnets, so that traffic
+        # from the internet can reach the load balancer directly via the internet gateway
+        - !Ref PublicSubnetOne
+        - !Ref PublicSubnetTwo
+      SecurityGroups: [!Ref 'PublicLoadBalancerSG']
+  # A dummy target group is used to setup the ALB to just drop traffic
+  # initially, before any real service target groups have been added.
+  DummyTargetGroupPublic:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      HealthCheckIntervalSeconds: 6
+      HealthCheckPath: /
+      HealthCheckProtocol: HTTP
+      HealthCheckTimeoutSeconds: 5
+      HealthyThresholdCount: 2
+      Name: !Join ['-', [!Ref 'AWS::StackName', 'drop-1']]
+      Port: 80
+      Protocol: HTTP
+      UnhealthyThresholdCount: 2
+      VpcId: !Ref 'VPC'
+  PublicLoadBalancerListener80:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    DependsOn:
+      - PublicLoadBalancer
+    Properties:
+      DefaultActions:
+        - TargetGroupArn: !Ref 'DummyTargetGroupPublic'
+          Type: 'forward'
+      LoadBalancerArn: !Ref 'PublicLoadBalancer'
+      Port: 80
+      Protocol: HTTP
+  PublicLoadBalancerListener443:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    DependsOn:
+      - PublicLoadBalancer
+    Properties:
+      Certificates:
+        - CertificateArn: !FindInMap [SSLCertificateMap, !Ref 'SSLCertificateName', Id]
+      DefaultActions:
+        - TargetGroupArn: !Ref 'DummyTargetGroupPublic'
+          Type: 'forward'
+      LoadBalancerArn: !Ref 'PublicLoadBalancer'
+      Port: 443
+      Protocol: HTTPS
+
+  # This is an IAM role which authorizes ECS to manage resources on your
+  # account on your behalf, such as updating your load balancer with the
+  # details of where your containers are, so that traffic can reach your
+  # containers.
+  ECSRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service: [ecs.amazonaws.com]
+          Action: ['sts:AssumeRole']
+      Path: /
+      Policies:
+      - PolicyName: ecs-service
+        PolicyDocument:
+          Statement:
+          - Effect: Allow
+            Action:
+              # Rules which allow ECS to attach network interfaces to instances
+              # on your behalf in order for awsvpc networking mode to work right
+              - 'ec2:AttachNetworkInterface'
+              - 'ec2:CreateNetworkInterface'
+              - 'ec2:CreateNetworkInterfacePermission'
+              - 'ec2:DeleteNetworkInterface'
+              - 'ec2:DeleteNetworkInterfacePermission'
+              - 'ec2:Describe*'
+              - 'ec2:DetachNetworkInterface'
+
+              # Rules which allow ECS to update load balancers on your behalf
+              # with the information sabout how to send traffic to your containers
+              - 'elasticloadbalancing:DeregisterInstancesFromLoadBalancer'
+              - 'elasticloadbalancing:DeregisterTargets'
+              - 'elasticloadbalancing:Describe*'
+              - 'elasticloadbalancing:RegisterInstancesWithLoadBalancer'
+              - 'elasticloadbalancing:RegisterTargets'
+            Resource: '*'
+
+  # This is a role which is used by the ECS tasks themselves.
+  ECSTaskExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service: [ecs-tasks.amazonaws.com]
+          Action: ['sts:AssumeRole']
+      Path: /
+      Policies:
+        - PolicyName: AmazonECSTaskExecutionRolePolicy
+          PolicyDocument:
+            Statement:
+            - Effect: Allow
+              Action:
+                # Allow the ECS Tasks to download images from ECR
+                - 'ecr:GetAuthorizationToken'
+                - 'ecr:BatchCheckLayerAvailability'
+                - 'ecr:GetDownloadUrlForLayer'
+                - 'ecr:BatchGetImage'
+
+                # Allow the ECS tasks to upload logs to CloudWatch
+                - 'logs:CreateLogStream'
+                - 'logs:PutLogEvents'
+              Resource: '*'
+
+  DNSRecord:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      HostedZoneName: !Join ['', [!Ref HostedZoneName, .]]
+      Name: !Join ['', [!Ref Subdomain, ., !Ref HostedZoneName, .]]
+      Type: A
+      AliasTarget:
+        DNSName: !GetAtt 'PublicLoadBalancer.DNSName'
+        HostedZoneId: !GetAtt 'PublicLoadBalancer.CanonicalHostedZoneID'
+
+# These are the values output by the CloudFormation template. Be careful
+# about changing any of them, because of them are exported with specific
+# names so that the other task related CF templates can use them.
+Outputs:
+  ClusterName:
+    Description: The name of the ECS cluster
+    Value: !Ref 'ECSCluster'
+    Export:
+      Name: !Join [ ':', [ !Ref 'AWS::StackName', 'ClusterName' ] ]
+  ExternalUrl:
+    Description: The url of the external load balancer
+    Value: !Join ['', ['http://', !GetAtt 'PublicLoadBalancer.DNSName']]
+    Export:
+      Name: !Join [ ':', [ !Ref 'AWS::StackName', 'ExternalUrl' ] ]
+  ECSRole:
+    Description: The ARN of the ECS role
+    Value: !GetAtt 'ECSRole.Arn'
+    Export:
+      Name: !Join [ ':', [ !Ref 'AWS::StackName', 'ECSRole' ] ]
+  ECSTaskExecutionRole:
+    Description: The ARN of the ECS role
+    Value: !GetAtt 'ECSTaskExecutionRole.Arn'
+    Export:
+      Name: !Join [ ':', [ !Ref 'AWS::StackName', 'ECSTaskExecutionRole' ] ]
+  PublicListener80:
+    Description: The ARN of the public load balancer's HTTP listener
+    Value: !Ref PublicLoadBalancerListener80
+    Export:
+      Name: !Join [ ':', [ !Ref 'AWS::StackName', 'PublicListener80' ] ]
+  PublicListener443:
+    Description: The ARN of the public load balancer's HTTPS listener
+    Value: !Ref PublicLoadBalancerListener443
+    Export:
+      Name: !Join [ ':', [ !Ref 'AWS::StackName', 'PublicListener443' ] ]
+  VPCId:
+    Description: The ID of the VPC that this stack is deployed in
+    Value: !Ref 'VPC'
+    Export:
+      Name: !Join [ ':', [ !Ref 'AWS::StackName', 'VPCId' ] ]
+  PublicSubnetOne:
+    Description: Public subnet one
+    Value: !Ref 'PublicSubnetOne'
+    Export:
+      Name: !Join [ ':', [ !Ref 'AWS::StackName', 'PublicSubnetOne' ] ]
+  PublicSubnetTwo:
+    Description: Public subnet two
+    Value: !Ref 'PublicSubnetTwo'
+    Export:
+      Name: !Join [ ':', [ !Ref 'AWS::StackName', 'PublicSubnetTwo' ] ]
+  FargateContainerSecurityGroup:
+    Description: A security group used to allow Fargate containers to receive traffic
+    Value: !Ref 'FargateContainerSecurityGroup'
+    Export:
+      Name: !Join [ ':', [ !Ref 'AWS::StackName', 'FargateContainerSecurityGroup' ] ]

--- a/fargate/public-network-stack.yml
+++ b/fargate/public-network-stack.yml
@@ -169,7 +169,7 @@ Resources:
       Scheme: internet-facing
       LoadBalancerAttributes:
       - Key: idle_timeout.timeout_seconds
-        Value: '30'
+        Value: '600'
       Subnets:
         # The load balancer is placed into the public subnets, so that traffic
         # from the internet can reach the load balancer directly via the internet gateway

--- a/fargate/public-network-stack.yml
+++ b/fargate/public-network-stack.yml
@@ -19,6 +19,21 @@ Parameters:
     Type: String
     Default: apps
     Description: The sub-domain to add to Route53 DNS record
+  VPC:
+    Type: AWS::EC2::VPC::Id
+    Description: The existing VPC to use
+  PublicSubnetOneCIDR:
+    AllowedPattern: '((\d{1,3})\.){3}\d{1,3}/\d{1,2}'
+    Description: VPC CIDR Block for first subnet created (eg 10.0.0.0/16 - must be within VPC)
+    Type: String
+  PublicSubnetTwoCIDR:
+    AllowedPattern: '((\d{1,3})\.){3}\d{1,3}/\d{1,2}'
+    Description: VPC CIDR Block for second subnet created (eg 10.0.1.0/16 - must be within VPC)
+    Type: String
+  InternetGateway:
+    Type: String
+    Description: Internet gateway id assigned to VPC
+
 Mappings:
   SSLCertificateMap:
     star.concord.org:
@@ -27,36 +42,18 @@ Mappings:
       Id: arn:aws:acm:us-east-1:612297603577:certificate/8297f3b1-eb86-4f91-8035-3fbd2c9f5560
     star.concordqa.org:
       Id: arn:aws:acm:us-east-1:816253370536:certificate/7b8bb00e-7aa4-4b9f-a722-f49c828af83c
-  # Hard values for the subnet masks. These masks define
-  # the range of internal IP addresses that can be assigned.
-  # The VPC can have all IP's from 10.0.0.0 to 10.0.255.255
-  # There are two subnets which cover the ranges:
-  #
-  # 10.0.0.0 - 10.0.0.255
-  # 10.0.1.0 - 10.0.1.255
-  #
-  # If you need more IP addresses (perhaps you have so many
-  # instances that you run out) then you can customize these
-  # ranges to add more
-  SubnetConfig:
-    VPC:
-      CIDR: '10.0.0.0/16'
-    PublicOne:
-      CIDR: '10.0.0.0/24'
-    PublicTwo:
-      CIDR: '10.0.1.0/24'
 Resources:
   # VPC in which containers will be networked.
   # It has two public subnets
   # We distribute the subnets across the first two available subnets
   # for the region, for high availability.
-  VPC:
-    Type: AWS::EC2::VPC
-    Properties:
-      EnableDnsSupport: true
-      EnableDnsHostnames: true
-      CidrBlock: !FindInMap ['SubnetConfig', 'VPC', 'CIDR']
-
+  #  VPC:
+  #    Type: AWS::EC2::VPC
+  #    Properties:
+  #      EnableDnsSupport: true
+  #      EnableDnsHostnames: true
+  #      CidrBlock: !FindInMap ['SubnetConfig', 'VPC', 'CIDR']
+  #
   # Two public subnets, where containers can have public IP addresses
   PublicSubnetOne:
     Type: AWS::EC2::Subnet
@@ -66,7 +63,7 @@ Resources:
          - 0
          - Fn::GetAZs: {Ref: 'AWS::Region'}
       VpcId: !Ref 'VPC'
-      CidrBlock: !FindInMap ['SubnetConfig', 'PublicOne', 'CIDR']
+      CidrBlock: !Ref 'PublicSubnetOneCIDR'
       MapPublicIpOnLaunch: true
   PublicSubnetTwo:
     Type: AWS::EC2::Subnet
@@ -76,26 +73,26 @@ Resources:
          - 1
          - Fn::GetAZs: {Ref: 'AWS::Region'}
       VpcId: !Ref 'VPC'
-      CidrBlock: !FindInMap ['SubnetConfig', 'PublicTwo', 'CIDR']
+      CidrBlock: !Ref 'PublicSubnetTwoCIDR'
       MapPublicIpOnLaunch: true
 
   # Setup networking resources for the public subnets. Containers
   # in the public subnets have public IP addresses and the routing table
   # sends network traffic via the internet gateway.
-  InternetGateway:
-    Type: AWS::EC2::InternetGateway
-  GatewayAttachement:
-    Type: AWS::EC2::VPCGatewayAttachment
-    Properties:
-      VpcId: !Ref 'VPC'
-      InternetGatewayId: !Ref 'InternetGateway'
+  # InternetGateway:
+  #   Type: AWS::EC2::InternetGateway
+  # GatewayAttachement:
+  #   Type: AWS::EC2::VPCGatewayAttachment
+  #   Properties:
+  #     VpcId: !Ref 'VPC'
+  #     InternetGatewayId: !Ref 'InternetGateway'
   PublicRouteTable:
     Type: AWS::EC2::RouteTable
     Properties:
       VpcId: !Ref 'VPC'
   PublicRoute:
     Type: AWS::EC2::Route
-    DependsOn: GatewayAttachement
+    # DependsOn: GatewayAttachement
     Properties:
       RouteTableId: !Ref 'PublicRouteTable'
       DestinationCidrBlock: '0.0.0.0/0'

--- a/fargate/te-report-prototype.yml
+++ b/fargate/te-report-prototype.yml
@@ -1,0 +1,194 @@
+# adapted from https://github.com/nathanpeck/aws-cloudformation-fargate/
+
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Deploy te-report-prototype on AWS Fargate, hosted in a public subnet, and accessible via a public load balancer.
+Parameters:
+  StackName:
+    Type: String
+    Default: fargate-public-network
+    Description: The name of the parent Fargate networking stack that you created. Necessary
+                 to locate and reference resources created by that stack.
+  ServiceName:
+    Type: String
+    Default: te-report-prototype
+    Description: A name for the service
+  ImageUrl:
+    Type: String
+    Default: concordconsortium/te-report-prototype
+    Description: The url of a docker image that contains the application process that
+                 will handle the traffic for this service
+  ContainerPort:
+    Type: Number
+    Default: 5000
+    Description: What port number the application inside the docker container is binding to
+  ContainerCpu:
+    Type: Number
+    Default: 1024
+    Description: How much CPU to give the container. 1024 is 1 CPU
+  ContainerMemory:
+    Type: Number
+    Default: 2048
+    Description: How much memory in megabytes to give the container
+  Path:
+    Type: String
+    Default: "/te-report-prototype*"
+    Description: A path on the public load balancer that this service
+                 should be connected to. This should NOT be *.
+  Priority:
+    Type: Number
+    Default: 2
+    Description: The priority for the routing rule added to the load balancer.
+                 This only applies if your have multiple services which have been
+                 assigned to different paths on the load balancer.
+  DesiredCount:
+    Type: Number
+    Default: 2
+    Description: How many copies of the service task to run
+  JwtHmacSecret:
+    Type: String
+    Description: Shared HMAC secret with portal
+  AuthoringApiKey:
+    Type: String
+    Description: API key for LARA
+  AuthoringServer:
+    Type: String
+    Description: Domain name of authoring server
+    Default: authoring.concord.org
+  LearnServer:
+    Type: String
+    Description: Domain name of learn server
+    Default: learn.concord.org
+  PortalReportUrl:
+    Type: String
+    Description: Full url to portal-report
+    Default: https://apps.concord.org/log-puller/portal-report
+
+Resources:
+
+  # The task definition. This is a simple metadata description of what
+  # container to run, and what resource requirements it has.
+  TaskDefinition:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      Family: !Ref 'ServiceName'
+      Cpu: !Ref 'ContainerCpu'
+      Memory: !Ref 'ContainerMemory'
+      NetworkMode: awsvpc
+      RequiresCompatibilities:
+        - FARGATE
+      ExecutionRoleArn:
+        Fn::ImportValue:
+          !Join [':', [!Ref 'StackName', 'ECSTaskExecutionRole']]
+      ContainerDefinitions:
+        - Name: !Ref 'ServiceName'
+          Cpu: !Ref 'ContainerCpu'
+          Memory: !Ref 'ContainerMemory'
+          Image: !Ref 'ImageUrl'
+          PortMappings:
+            - ContainerPort: !Ref 'ContainerPort'
+          Environment:
+            - Name: JWT_HMAC_SECRET
+              Value: !Ref JwtHmacSecret
+            - Name: AUTHORING_API_KEY
+              Value: !Ref AuthoringApiKey
+            - Name: AUTHORING_SERVER
+              Value: !Ref AuthoringServer
+            - Name: LEARN_SERVER
+              Value: !Ref LearnServer
+            - Name: PORTAL_REPORT_URL
+              Value: !Ref PortalReportUrl
+
+  # The service. The service is a resource which allows you to run multiple
+  # copies of a type of task, and gather up their logs and metrics, as well
+  # as monitor the number of running tasks and replace any that have crashed
+  Service:
+    Type: AWS::ECS::Service
+    DependsOn:
+      - LoadBalancerRule80
+      - LoadBalancerRule443
+    Properties:
+      ServiceName: !Ref 'ServiceName'
+      Cluster:
+        Fn::ImportValue:
+          !Join [':', [!Ref 'StackName', 'ClusterName']]
+      LaunchType: FARGATE
+      DeploymentConfiguration:
+        MaximumPercent: 200
+        MinimumHealthyPercent: 75
+      DesiredCount: !Ref 'DesiredCount'
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          AssignPublicIp: ENABLED
+          SecurityGroups:
+            - Fn::ImportValue:
+                !Join [':', [!Ref 'StackName', 'FargateContainerSecurityGroup']]
+            - !Ref ServiceSecurityGroup
+          Subnets:
+            - Fn::ImportValue:
+                !Join [':', [!Ref 'StackName', 'PublicSubnetOne']]
+            - Fn::ImportValue:
+                !Join [':', [!Ref 'StackName', 'PublicSubnetTwo']]
+      TaskDefinition: !Ref 'TaskDefinition'
+      LoadBalancers:
+        - ContainerName: !Ref 'ServiceName'
+          ContainerPort: !Ref 'ContainerPort'
+          TargetGroupArn: !Ref 'TargetGroup'
+
+  ServiceSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: TE Report ECS service security group
+      VpcId:
+        Fn::ImportValue:
+          !Join [':', [!Ref 'StackName', 'VPCId']]
+
+  # A target group. This is used for keeping track of all the tasks, and
+  # what IP addresses / port numbers they have. You can query it yourself,
+  # to use the addresses yourself, but most often this target group is just
+  # connected to an application load balancer, or network load balancer, so
+  # it can automatically distribute traffic across all the targets.
+  TargetGroup:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      HealthCheckIntervalSeconds: 6
+      HealthCheckPath: /
+      HealthCheckProtocol: HTTP
+      HealthCheckTimeoutSeconds: 5
+      HealthyThresholdCount: 2
+      TargetType: ip
+      Name: !Ref 'ServiceName'
+      Port: !Ref 'ContainerPort'
+      Protocol: HTTP
+      UnhealthyThresholdCount: 2
+      VpcId:
+        Fn::ImportValue:
+          !Join [':', [!Ref 'StackName', 'VPCId']]
+
+  LoadBalancerRule80:
+    Type: AWS::ElasticLoadBalancingV2::ListenerRule
+    Properties:
+      Actions:
+        - TargetGroupArn: !Ref 'TargetGroup'
+          Type: 'forward'
+      Conditions:
+        - Field: path-pattern
+          Values: [!Ref 'Path']
+      ListenerArn:
+        Fn::ImportValue:
+          !Join [':', [!Ref 'StackName', 'PublicListener80']]
+      Priority: !Ref 'Priority'
+  LoadBalancerRule443:
+    Type: AWS::ElasticLoadBalancingV2::ListenerRule
+    Properties:
+      Actions:
+        - TargetGroupArn: !Ref 'TargetGroup'
+          Type: 'forward'
+      Conditions:
+        - Field: path-pattern
+          Values: [!Ref 'Path']
+      ListenerArn:
+        Fn::ImportValue:
+          !Join [':', [!Ref 'StackName', 'PublicListener443']]
+      Priority: !Ref 'Priority'
+
+

--- a/log-ingester.yml
+++ b/log-ingester.yml
@@ -48,16 +48,27 @@ Parameters:
 
   ApiGatewayBasePath:
     Type: String
-    Description: Base path for API at https://api.concord.org/ (staging should use log-staging)
+    Description: Base path for API at https://api.concord.org/ or https://api.concordqa.org/
     Default: log
+
+  ApiDomain:
+    Type: String
+    Description: The domain of the api
+    Default: api.concordqa.org
+    AllowedValues: [api.concord.org, api.concordqa.org]
 
   AlarmEmail:
     Type: String
-    Description: Email address to notify when the log ingester has triggered an alarm
+    Description: Email address to notify when the log ingester has triggered an alarm and for tags
+
+  LambdaZipBucket:
+    Type: String
+    Description: S3 bucket containing /log-ingester folder containing LambdaZipFilename
+    Default: concord-devops
 
   LambdaZipFilename:
     Type: String
-    Description: Filename of lambda .zip file in s3://concord-devops/log-ingester
+    Description: Filename of lambda .zip file in log-ingester folder of the LambdaZipBucket
     Default: kinesis-to-rds.zip
 
 
@@ -102,7 +113,7 @@ Resources:
         - !Ref DBVPCSecurityGroup
       Tags:
         - Key: Contact
-          Value: dmartin
+          Value: !Ref AlarmEmail
         - Key: Environment
           Value: !Ref "Environment"
   # no changes to parameters, just here in case we need to add any
@@ -113,7 +124,7 @@ Resources:
       Family: postgres10
       Tags:
         - Key: Contact
-          Value: dmartin
+          Value: !Ref AlarmEmail
         - Key: Environment
           Value: !Ref "Environment"
   DBVPCSecurityGroup:
@@ -127,13 +138,12 @@ Resources:
         - IpProtocol: tcp
           FromPort: 5432
           ToPort: 5432
-          CidrIp: 0.0.0.0/0
       SecurityGroupEgress:
         - IpProtocol: "-1"
           CidrIp: 0.0.0.0/0
       Tags:
         - Key: Contact
-          Value: dmartin
+          Value: !Ref AlarmEmail
         - Key: Environment
           Value: !Ref "Environment"
   DBSubnetGroup:
@@ -144,7 +154,7 @@ Resources:
       SubnetIds: !Ref "DbSubnetIds"
       Tags:
         - Key: Contact
-          Value: dmartin
+          Value: !Ref AlarmEmail
         - Key: Environment
           Value: !Ref "Environment"
 
@@ -185,31 +195,36 @@ Resources:
       Timeout: 60
       VpcConfig:
         SecurityGroupIds:
-          - !Ref DBVPCSecurityGroup
-          # - !Ref KinesisToRDSLambdaFunctionSecurityGroup
+          - !Ref KinesisToRDSLambdaFunctionSecurityGroup
         SubnetIds: !Ref "DbSubnetIds"
       Environment:
         Variables:
           RDS_DATABASE_URL: !Sub "postgres://${DbUser}:${DbPassword}@${DBInstance.Endpoint.Address}/log_manager"
       Code:
-        S3Bucket: concord-devops
+        S3Bucket: !Ref LambdaZipBucket
         S3Key: !Sub "log-ingester/${LambdaZipFilename}"
       Tags:
         - Key: Contact
-          Value: dmartin
+          Value: !Ref AlarmEmail
         - Key: Environment
           Value: !Ref "Environment"
 
   KinesisToRDSLambdaFunctionSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
+      GroupName: !Sub "log-ingester-${Environment}-kinesis-to-rds-lambda"
       GroupDescription: Kinesis to RDS Lambda Function security group
       VpcId: !Ref "VpcId"
-      SecurityGroupIngress:
-        - IpProtocol: tcp
-          FromPort: 5432
-          ToPort: 5432
-          SourceSecurityGroupId: !Ref DBVPCSecurityGroup
+
+  KinesisToRDSLambdaFunctionDBIngress:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      Description: Adds log ingester lambda to RDS security group
+      GroupId: !Ref DBVPCSecurityGroup
+      IpProtocol: tcp
+      FromPort: 5432
+      ToPort: 5432
+      SourceSecurityGroupId: !Ref KinesisToRDSLambdaFunctionSecurityGroup
 
   LambdaIamRole:
     Type: AWS::IAM::Role
@@ -418,7 +433,7 @@ Resources:
     DependsOn: ApiGatewayStage
     Properties:
       BasePath: !Ref ApiGatewayBasePath
-      DomainName: api.concord.org
+      DomainName: !Ref ApiDomain
       RestApiId: !Ref ApiGateway
       Stage: latest
 
@@ -477,7 +492,7 @@ Outputs:
     Value: !Sub "https://${ApiGateway}.execute-api.${AWS::Region}.amazonaws.com/latest/logs"
   NiceIngestionUrl:
     Description: Nice URL of the API gateway log ingester
-    Value: !Sub "https://api.concord.org/${ApiGatewayBasePath}/logs"
+    Value: !Sub "https://${ApiDomain}/${ApiGatewayBasePath}/logs"
   RdsDatabaseUrl:
     Description: Connection string for Heroku log-puller
     Value: !Sub "postgres://${DbUser}:${DbPassword}@${DBInstance.Endpoint.Address}/log_manager"

--- a/log-ingester.yml
+++ b/log-ingester.yml
@@ -499,3 +499,5 @@ Outputs:
   RdsSecurityGroup:
     Description: RDS VPC security group
     Value: !Ref DBVPCSecurityGroup
+    Export:
+      Name: !Join [ ':', [ !Ref 'AWS::StackName', 'RdsSecurityGroup' ] ]

--- a/log-ingester.yml
+++ b/log-ingester.yml
@@ -186,6 +186,7 @@ Resources:
       VpcConfig:
         SecurityGroupIds:
           - !Ref DBVPCSecurityGroup
+          # - !Ref KinesisToRDSLambdaFunctionSecurityGroup
         SubnetIds: !Ref "DbSubnetIds"
       Environment:
         Variables:
@@ -198,6 +199,17 @@ Resources:
           Value: dmartin
         - Key: Environment
           Value: !Ref "Environment"
+
+  KinesisToRDSLambdaFunctionSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Kinesis to RDS Lambda Function security group
+      VpcId: !Ref "VpcId"
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 5432
+          ToPort: 5432
+          SourceSecurityGroupId: !Ref DBVPCSecurityGroup
 
   LambdaIamRole:
     Type: AWS::IAM::Role
@@ -432,7 +444,7 @@ Resources:
           Name: ApiName
           Value: !Sub "log-ingester-${Environment}"
       MetricName: "5XXError"
-      Namespace: AWS/Api­Gateway
+      Namespace: AWS/ApiGateway
       ComparisonOperator: GreaterThanOrEqualToThreshold
       EvaluationPeriods: 1
       Period: 300
@@ -469,3 +481,6 @@ Outputs:
   RdsDatabaseUrl:
     Description: Connection string for Heroku log-puller
     Value: !Sub "postgres://${DbUser}:${DbPassword}@${DBInstance.Endpoint.Address}/log_manager"
+  RdsSecurityGroup:
+    Description: RDS VPC security group
+    Value: !Ref DBVPCSecurityGroup


### PR DESCRIPTION
Sets up a single Fargate public network with a load balancer with a parameterized Route 53 A recordset and the `log-puller` service that lives in a subfolder of the load balancer.  This will allow us to create other Dockerized services and deploy them in other subfolders.

Deployed currently at https://apps.concordqa.org/log-puller with portal staging reports set to that url.