### PR TITLE
Fixed hidden unicode character in gateway alarm namespace

### DIFF
--- a/question-rater.yml
+++ b/question-rater.yml
@@ -210,7 +210,7 @@ Resources:
           Name: ApiName
           Value: !Sub "question-rater-${Environment}"
       MetricName: "5XXError"
-      Namespace: AWS/Api­Gateway
+      Namespace: AWS/ApiGateway
       ComparisonOperator: GreaterThanOrEqualToThreshold
       EvaluationPeriods: 1
       Period: 300


### PR DESCRIPTION
This was causing the alarm not to be created