### PR TITLE
Fixed API Gateway logging, was disabled

### DIFF
--- a/log-ingester.yml
+++ b/log-ingester.yml
@@ -309,7 +309,7 @@ Resources:
       MethodSettings:
         -
           DataTraceEnabled: true
-          HttpMethod: POST
+          HttpMethod: "*"
           LoggingLevel: INFO
           ResourcePath: "/*"
       RestApiId: !Ref ApiGateway

--- a/question-rater.yml
+++ b/question-rater.yml
@@ -131,7 +131,7 @@ Resources:
       MethodSettings:
         -
           DataTraceEnabled: true
-          HttpMethod: POST
+          HttpMethod: "*"
           LoggingLevel: INFO
           ResourcePath: "/*"
       RestApiId: !Ref ApiGateway


### PR DESCRIPTION
The HttpMethod setting of POST was not enabling the logging, changed to * based on forum post in aws support.