### PR TITLE
template to setup generic project resources

### DIFF
--- a/generic-project-resources-cloudfront.yml
+++ b/generic-project-resources-cloudfront.yml
@@ -1,0 +1,55 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: generic cloudfront and domain for project-resources
+Resources:
+  DNS:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      AliasTarget:
+        # need to get this from the cloudfront distribution
+        DNSName: !GetAtt CloudFrontDistribution.DomainName
+        # static zone id from documentation
+        HostedZoneId: Z2FDTNDATAQYW2
+      HostedZoneName: concord.org.
+      Name: project-resources.concord.org
+      Type: A
+  CloudFrontDistribution:
+    Type: AWS::CloudFront::Distribution
+    Properties:
+      DistributionConfig:
+        Aliases:
+        - project-resources.concord.org
+        Comment: Generic Cloudfront Distribution for project resources
+        DefaultCacheBehavior:
+          AllowedMethods:
+          - GET
+          - HEAD
+          Compress: true
+          ForwardedValues:
+            QueryString: true
+            Cookies:
+              Forward: none
+            # support CORS Requests to the resources
+            Headers:
+            - Origin
+            - Access-Control-Request-Headers
+            - Access-Control-Request-Method
+          TargetOriginId: S3Origin
+          ViewerProtocolPolicy: redirect-to-https
+        Enabled: true
+        HttpVersion: http2
+        Logging:
+          Bucket: cc-cloudfront-logs.s3.amazonaws.com
+          IncludeCookies: false
+          Prefix: project-resources
+        PriceClass: PriceClass_All
+        Origins:
+        # use the S3 website domain so requests to / will load in index.html
+        # more info: https://docs.aws.amazon.com/AmazonS3/latest/dev/WebsiteEndpoints.html#WebsiteRestEndpointDiff
+        - DomainName: cc-project-resources.s3-website-us-east-1.amazonaws.com
+          Id: S3Origin
+          CustomOriginConfig:
+            # S3 website domain only supports http
+            OriginProtocolPolicy: http-only
+        ViewerCertificate:
+          AcmCertificateArn: arn:aws:acm:us-east-1:612297603577:certificate/2b62511e-ccc8-434b-ba6c-a8c33bbd509e
+          SslSupportMethod: sni-only


### PR DESCRIPTION
For projects that don't need to share URLs to their resources, this approach
saves us a cloudfront distribution and DNS entry.
I'd suspect most projects don't share their resource URLs. These are
just used for images and videos inside of their content.

A project that wants to use this still needs an IAM role and group created
to restrict them to just their project folder. That would be in a new template.
That template could be extracted from the project-resources-with-domain template.