### PR TITLE
Portal and LARA code pipeline

### DIFF
--- a/portal-lara-pipeline.yml
+++ b/portal-lara-pipeline.yml
@@ -2,6 +2,10 @@ AWSTemplateFormatVersion: '2010-09-09'
 Description: Portal or LARA Code Pipeline
 
 Parameters:
+  PipelineName:
+    Type: String
+    Description: This will be used for the name of the pipeline, it typically should be the
+      domain name that is being managed by the pipeline.
   RepoName:
     Type: String
     AllowedValues: [rigse, lara]
@@ -28,7 +32,7 @@ Resources:
   AppPipeline:
     Type: 'AWS::CodePipeline::Pipeline'
     Properties:
-      Name: !Sub "${RepoName}-${BranchName}"
+      Name: !Ref PipelineName
       RoleArn: arn:aws:iam::816253370536:role/service-role/AWSCodePipelineServiceRole-us-east-1-learn-qa
       Stages:
         - Name: Source

--- a/portal-lara-pipeline.yml
+++ b/portal-lara-pipeline.yml
@@ -1,7 +1,13 @@
 AWSTemplateFormatVersion: '2010-09-09'
-Description: Portal Code Pipeline
+Description: Portal or LARA Code Pipeline
 
 Parameters:
+  RepoName:
+    Type: String
+    AllowedValues: [rigse, lara]
+    Description: This will be appended to 'concord-consortium/' to make the full repository name
+      and if it is lara then the report service won't be configured. This will also be used
+      for the CodeBuild project name
   AppServiceName:
     Type: String
     Description: The name of the ECS service for the App that the pipeline will update
@@ -15,11 +21,14 @@ Parameters:
     Type: String
     Description: The name of the github branch to automatically deploy
 
+Conditions:
+  HasReportService: !Equals [!Ref RepoName, "rigse"]
+
 Resources:
   AppPipeline:
     Type: 'AWS::CodePipeline::Pipeline'
     Properties:
-      Name: codecommit-events-pipeline
+      Name: !Sub "${RepoName}-${BranchName}"
       RoleArn: arn:aws:iam::816253370536:role/service-role/AWSCodePipelineServiceRole-us-east-1-learn-qa
       Stages:
         - Name: Source
@@ -35,7 +44,7 @@ Resources:
               Configuration:
                 ConnectionArn: arn:aws:codestar-connections:us-east-1:816253370536:connection/73546caa-70a8-4125-88a1-edc428c32ad1
                 BranchName: !Ref BranchName
-                FullRepositoryId: concord-consortium/rigse
+                FullRepositoryId: !Sub concord-consortium/${RepoName}
                 DetectChanges: true
         - Name: Build
           Actions:
@@ -50,7 +59,7 @@ Resources:
               InputArtifacts:
                 - Name: SourceArtifact
               Configuration:
-                ProjectName: learn-qa
+                ProjectName: !Ref RepoName
                 EnvironmentVariables: !Sub |
                   [{ "name": "BRANCH_NAME",
                      "value": "${BranchName}",
@@ -82,18 +91,21 @@ Resources:
                 ClusterName: qa
                 ServiceName: !Ref WorkerServiceName
                 FileName: worker-imagedefinitions.json
-            - Name: UpdateReportService
-              ActionTypeId:
-                Category: Deploy
-                Owner: AWS
-                Version: 1
-                Provider: ECS
-              InputArtifacts:
-                - Name: BuildArtifact
-              Configuration:
-                ClusterName: qa
-                ServiceName: !Ref ReportServiceName
-                FileName: report-imagedefinitions.json
+            - !If
+              - HasReportService
+              - Name: UpdateReportService
+                ActionTypeId:
+                  Category: Deploy
+                  Owner: AWS
+                  Version: 1
+                  Provider: ECS
+                InputArtifacts:
+                  - Name: BuildArtifact
+                Configuration:
+                  ClusterName: qa
+                  ServiceName: !Ref ReportServiceName
+                  FileName: report-imagedefinitions.json
+              - !Ref 'AWS::NoValue'
       ArtifactStore:
         Type: S3
         Location: codepipeline-us-east-1-41654313229

--- a/portal-pipeline.yml
+++ b/portal-pipeline.yml
@@ -70,13 +70,11 @@ Resources:
                 Provider: CodeStarSourceConnection
               OutputArtifacts:
                 - Name: SourceArtifact
-              Configuration: !Sub |
-                {
-                  "ConnectionArn": "arn:aws:codestar-connections:us-east-1:816253370536:connection/73546caa-70a8-4125-88a1-edc428c32ad1",
-                  "BranchName": "${BranchName}",
-                  "RepositoryName": "concord-consortium/rigse",
-                  "DetectChanges": true
-                }
+              Configuration:
+                ConnectionArn: arn:aws:codestar-connections:us-east-1:816253370536:connection/73546caa-70a8-4125-88a1-edc428c32ad1
+                BranchName: !Ref BranchName
+                FullRepositoryId: concord-consortium/rigse
+                DetectChanges: true
         - Name: Build
           Actions:
             - Name: Build
@@ -89,17 +87,12 @@ Resources:
                 - Name: BuildArtifact
               InputArtifacts:
                 - Name: SourceArtifact
-              Configuration: !Sub |
-                {
-                  "ProjectName": "learn-qa",
-                  "EnvironmentVariables": [
-                    {
-                      "name": "BRANCH_NAME",
-                      "value": "${BranchName}",
-                      "type": "PLAINTEXT"
-                    }
-                  ]
-                }
+              Configuration:
+                ProjectName: learn-qa
+                # EnvironmentVariables:
+                #   - name: BRANCH_NAME
+                #     value: !Ref BranchName
+                #     type: PLAINTEXT
         - Name: Deploy
           Actions:
             - Name: UpdateAppService
@@ -110,12 +103,10 @@ Resources:
                 Provider: ECS
               InputArtifacts:
                 - Name: BuildArtifact
-              Configuration: !Sub |
-                {
-                  "ClusterName": "qa",
-                  "ServiceName": "${AppServiceName}",
-                  "FileName": "app-imagedefinitions.json"
-                }
+              Configuration:
+                ClusterName: qa
+                ServiceName: !Ref AppServiceName
+                FileName: app-imagedefinitions.json
             - Name: UpdateWorkerService
               ActionTypeId:
                 Category: Deploy
@@ -124,12 +115,10 @@ Resources:
                 Provider: ECS
               InputArtifacts:
                 - Name: BuildArtifact
-              Configuration: !Sub |
-                {
-                  "ClusterName": "qa",
-                  "ServiceName": "${WorkerServiceName}",
-                  "FileName": "worker-imagedefinitions.json"
-                }
+              Configuration:
+                ClusterName: qa
+                ServiceName: !Ref WorkerServiceName
+                FileName: worker-imagedefinitions.json
             - Name: UpdateReportService
               ActionTypeId:
                 Category: Deploy
@@ -138,12 +127,10 @@ Resources:
                 Provider: ECS
               InputArtifacts:
                 - Name: BuildArtifact
-              Configuration: !Sub |
-                {
-                  "ClusterName": "qa",
-                  "ServiceName": "${ReportServiceName}",
-                  "FileName": "report-imagedefinitions.json"
-                }
+              Configuration:
+                ClusterName: qa
+                ServiceName: !Ref ReportServiceName
+                FileName: report-imagedefinitions.json
       ArtifactStore:
         Type: S3
         Location: !Ref CodePipelineArtifactStoreBucket
@@ -216,4 +203,5 @@ Resources:
                   - 'rds:*'
                   - 'sqs:*'
                   - 'ecs:*'
+                  - 'codestar-connections:*'
                 Resource: '*'

--- a/portal-pipeline.yml
+++ b/portal-pipeline.yml
@@ -1,0 +1,219 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Portal Code Pipeline
+
+Parameters:
+  AppServiceName:
+    Type: String
+    Description: The name of the ECS service for the App that the pipeline will update
+  WorkerServiceName:
+    Type: String
+    Description: The name of the ECS service for the Worker that the pipeline will update
+  ReportServiceName:
+    Type: String
+    Description: The name of the ECS service for the Report that the pipeline will update
+  BranchName:
+    Type: String
+    Description: The name of the github branch to automatically deploy
+
+Resources:
+  CodePipelineArtifactStoreBucket:
+    Type: 'AWS::S3::Bucket'
+  CodePipelineArtifactStoreBucketPolicy:
+    Type: 'AWS::S3::BucketPolicy'
+    Properties:
+      Bucket: !Ref CodePipelineArtifactStoreBucket
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: DenyUnEncryptedObjectUploads
+            Effect: Deny
+            Principal: '*'
+            Action: 's3:PutObject'
+            Resource: !Join
+              - ''
+              - - !GetAtt
+                  - CodePipelineArtifactStoreBucket
+                  - Arn
+                - /*
+            Condition:
+              StringNotEquals:
+                's3:x-amz-server-side-encryption': 'aws:kms'
+          - Sid: DenyInsecureConnections
+            Effect: Deny
+            Principal: '*'
+            Action: 's3:*'
+            Resource: !Join
+              - ''
+              - - !GetAtt
+                  - CodePipelineArtifactStoreBucket
+                  - Arn
+                - /*
+            Condition:
+              Bool:
+                'aws:SecureTransport': false
+
+  AppPipeline:
+    Type: 'AWS::CodePipeline::Pipeline'
+    Properties:
+      Name: codecommit-events-pipeline
+      RoleArn: !GetAtt
+        - CodePipelineServiceRole
+        - Arn
+      Stages:
+        - Name: Source
+          Actions:
+            - Name: Source
+              ActionTypeId:
+                Category: Source
+                Owner: AWS
+                Version: 1
+                Provider: CodeStarSourceConnection
+              OutputArtifacts:
+                - Name: SourceArtifact
+              Configuration: !Sub |
+                {
+                  "ConnectionArn": "arn:aws:codestar-connections:us-east-1:816253370536:connection/73546caa-70a8-4125-88a1-edc428c32ad1",
+                  "BranchName": "${BranchName}",
+                  "RepositoryName": "concord-consortium/rigse",
+                  "DetectChanges": true
+                }
+        - Name: Build
+          Actions:
+            - Name: Build
+              ActionTypeId:
+                Category: Build
+                Owner: AWS
+                Version: 1
+                Provider: CodeBuild
+              OutputArtifacts:
+                - Name: BuildArtifact
+              InputArtifacts:
+                - Name: SourceArtifact
+              Configuration: !Sub |
+                {
+                  "ProjectName": "learn-qa",
+                  "EnvironmentVariables": [
+                    {
+                      "name": "BRANCH_NAME",
+                      "value": "${BranchName}",
+                      "type": "PLAINTEXT"
+                    }
+                  ]
+                }
+        - Name: Deploy
+          Actions:
+            - Name: UpdateAppService
+              ActionTypeId:
+                Category: Deploy
+                Owner: AWS
+                Version: 1
+                Provider: ECS
+              InputArtifacts:
+                - Name: BuildArtifact
+              Configuration: !Sub |
+                {
+                  "ClusterName": "qa",
+                  "ServiceName": "${AppServiceName}",
+                  "FileName": "app-imagedefinitions.json"
+                }
+            - Name: UpdateWorkerService
+              ActionTypeId:
+                Category: Deploy
+                Owner: AWS
+                Version: 1
+                Provider: ECS
+              InputArtifacts:
+                - Name: BuildArtifact
+              Configuration: !Sub |
+                {
+                  "ClusterName": "qa",
+                  "ServiceName": "${WorkerServiceName}",
+                  "FileName": "worker-imagedefinitions.json"
+                }
+            - Name: UpdateReportService
+              ActionTypeId:
+                Category: Deploy
+                Owner: AWS
+                Version: 1
+                Provider: ECS
+              InputArtifacts:
+                - Name: BuildArtifact
+              Configuration: !Sub |
+                {
+                  "ClusterName": "qa",
+                  "ServiceName": "${ReportServiceName}",
+                  "FileName": "report-imagedefinitions.json"
+                }
+      ArtifactStore:
+        Type: S3
+        Location: !Ref CodePipelineArtifactStoreBucket
+  CodePipelineServiceRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - codepipeline.amazonaws.com
+            Action: 'sts:AssumeRole'
+      Path: /
+      Policies:
+        - PolicyName: AWS-CodePipeline-Service-3
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - 'codecommit:CancelUploadArchive'
+                  - 'codecommit:GetBranch'
+                  - 'codecommit:GetCommit'
+                  - 'codecommit:GetUploadArchiveStatus'
+                  - 'codecommit:UploadArchive'
+                Resource: '*'
+              - Effect: Allow
+                Action:
+                  - 'codedeploy:CreateDeployment'
+                  - 'codedeploy:GetApplicationRevision'
+                  - 'codedeploy:GetDeployment'
+                  - 'codedeploy:GetDeploymentConfig'
+                  - 'codedeploy:RegisterApplicationRevision'
+                Resource: '*'
+              - Effect: Allow
+                Action:
+                  - 'codebuild:BatchGetBuilds'
+                  - 'codebuild:StartBuild'
+                Resource: '*'
+              - Effect: Allow
+                Action:
+                  - 'devicefarm:ListProjects'
+                  - 'devicefarm:ListDevicePools'
+                  - 'devicefarm:GetRun'
+                  - 'devicefarm:GetUpload'
+                  - 'devicefarm:CreateUpload'
+                  - 'devicefarm:ScheduleRun'
+                Resource: '*'
+              - Effect: Allow
+                Action:
+                  - 'lambda:InvokeFunction'
+                  - 'lambda:ListFunctions'
+                Resource: '*'
+              - Effect: Allow
+                Action:
+                  - 'iam:PassRole'
+                Resource: '*'
+              - Effect: Allow
+                Action:
+                  - 'elasticbeanstalk:*'
+                  - 'ec2:*'
+                  - 'elasticloadbalancing:*'
+                  - 'autoscaling:*'
+                  - 'cloudwatch:*'
+                  - 's3:*'
+                  - 'sns:*'
+                  - 'cloudformation:*'
+                  - 'rds:*'
+                  - 'sqs:*'
+                  - 'ecs:*'
+                Resource: '*'

--- a/portal-pipeline.yml
+++ b/portal-pipeline.yml
@@ -16,49 +16,11 @@ Parameters:
     Description: The name of the github branch to automatically deploy
 
 Resources:
-  CodePipelineArtifactStoreBucket:
-    Type: 'AWS::S3::Bucket'
-  CodePipelineArtifactStoreBucketPolicy:
-    Type: 'AWS::S3::BucketPolicy'
-    Properties:
-      Bucket: !Ref CodePipelineArtifactStoreBucket
-      PolicyDocument:
-        Version: 2012-10-17
-        Statement:
-          - Sid: DenyUnEncryptedObjectUploads
-            Effect: Deny
-            Principal: '*'
-            Action: 's3:PutObject'
-            Resource: !Join
-              - ''
-              - - !GetAtt
-                  - CodePipelineArtifactStoreBucket
-                  - Arn
-                - /*
-            Condition:
-              StringNotEquals:
-                's3:x-amz-server-side-encryption': 'aws:kms'
-          - Sid: DenyInsecureConnections
-            Effect: Deny
-            Principal: '*'
-            Action: 's3:*'
-            Resource: !Join
-              - ''
-              - - !GetAtt
-                  - CodePipelineArtifactStoreBucket
-                  - Arn
-                - /*
-            Condition:
-              Bool:
-                'aws:SecureTransport': false
-
   AppPipeline:
     Type: 'AWS::CodePipeline::Pipeline'
     Properties:
       Name: codecommit-events-pipeline
-      RoleArn: !GetAtt
-        - CodePipelineServiceRole
-        - Arn
+      RoleArn: arn:aws:iam::816253370536:role/service-role/AWSCodePipelineServiceRole-us-east-1-learn-qa
       Stages:
         - Name: Source
           Actions:
@@ -89,10 +51,11 @@ Resources:
                 - Name: SourceArtifact
               Configuration:
                 ProjectName: learn-qa
-                # EnvironmentVariables:
-                #   - name: BRANCH_NAME
-                #     value: !Ref BranchName
-                #     type: PLAINTEXT
+                EnvironmentVariables: !Sub |
+                  [{ "name": "BRANCH_NAME",
+                     "value": "${BranchName}",
+                     "type": "PLAINTEXT"
+                   }]
         - Name: Deploy
           Actions:
             - Name: UpdateAppService
@@ -133,75 +96,4 @@ Resources:
                 FileName: report-imagedefinitions.json
       ArtifactStore:
         Type: S3
-        Location: !Ref CodePipelineArtifactStoreBucket
-  CodePipelineServiceRole:
-    Type: 'AWS::IAM::Role'
-    Properties:
-      AssumeRolePolicyDocument:
-        Version: 2012-10-17
-        Statement:
-          - Effect: Allow
-            Principal:
-              Service:
-                - codepipeline.amazonaws.com
-            Action: 'sts:AssumeRole'
-      Path: /
-      Policies:
-        - PolicyName: AWS-CodePipeline-Service-3
-          PolicyDocument:
-            Version: 2012-10-17
-            Statement:
-              - Effect: Allow
-                Action:
-                  - 'codecommit:CancelUploadArchive'
-                  - 'codecommit:GetBranch'
-                  - 'codecommit:GetCommit'
-                  - 'codecommit:GetUploadArchiveStatus'
-                  - 'codecommit:UploadArchive'
-                Resource: '*'
-              - Effect: Allow
-                Action:
-                  - 'codedeploy:CreateDeployment'
-                  - 'codedeploy:GetApplicationRevision'
-                  - 'codedeploy:GetDeployment'
-                  - 'codedeploy:GetDeploymentConfig'
-                  - 'codedeploy:RegisterApplicationRevision'
-                Resource: '*'
-              - Effect: Allow
-                Action:
-                  - 'codebuild:BatchGetBuilds'
-                  - 'codebuild:StartBuild'
-                Resource: '*'
-              - Effect: Allow
-                Action:
-                  - 'devicefarm:ListProjects'
-                  - 'devicefarm:ListDevicePools'
-                  - 'devicefarm:GetRun'
-                  - 'devicefarm:GetUpload'
-                  - 'devicefarm:CreateUpload'
-                  - 'devicefarm:ScheduleRun'
-                Resource: '*'
-              - Effect: Allow
-                Action:
-                  - 'lambda:InvokeFunction'
-                  - 'lambda:ListFunctions'
-                Resource: '*'
-              - Effect: Allow
-                Action:
-                  - 'iam:PassRole'
-                Resource: '*'
-              - Effect: Allow
-                Action:
-                  - 'elasticbeanstalk:*'
-                  - 'ec2:*'
-                  - 'elasticloadbalancing:*'
-                  - 'autoscaling:*'
-                  - 'cloudwatch:*'
-                  - 's3:*'
-                  - 'sns:*'
-                  - 'cloudformation:*'
-                  - 'rds:*'
-                  - 'sqs:*'
-                  - 'ecs:*'
-                  - 'codestar-connections:*'
-                Resource: '*'
+        Location: codepipeline-us-east-1-41654313229


### PR DESCRIPTION
This template sets up a AWS CodePipeline. 
It is used to keep a LARA or Portal instance up to date with a particular branch of the repository.