### PR TITLE
Added DisallowAllRobotsTxt parameter to portal configs

### DIFF
--- a/portal-app-only.yml
+++ b/portal-app-only.yml
@@ -135,10 +135,19 @@ Parameters:
     Description: This is the host name of the internal load balancer setup by the main
       stack.  You can find it in the Outputs of the InternalLoadBalancerStack. It is the
       ELBDNSName property.
+  DisallowAllRobotsTxt:
+    Type: String
+    Description: set to true to have portal generate robots.txt that disallows all user
+      agents.  This option is checked first in the robots controller.
+    Default: false
+    AllowedValues:
+    - true
+    - false
   DynamicRobotsTxt:
     Type: String
     Description: set to true to have portal generate robots.txt otherwise the default
-      robots.txt will be used which denies all access
+      robots.txt will be used which denies all access UNLESS the DisallowAllRobotsTxt
+      is set to true as it is checked first.
     Default: false
     AllowedValues:
     - true
@@ -348,6 +357,8 @@ Resources:
           Value: !Ref GoogleClientSecret
         - Name: RESTART_TOGGLE
           Value: !Ref RestartToggle
+        - Name: DISALLOW_ALL_ROBOTS_TXT
+          Value: !Ref DisallowAllRobotsTxt
         - Name: DYNAMIC_ROBOTS_TXT
           Value: !Ref DynamicRobotsTxt
         - Name: CC_PORTAL_VERSION

--- a/portal-ecs.yml
+++ b/portal-ecs.yml
@@ -158,10 +158,19 @@ Parameters:
     Type: String
     Description: change this value to cause a rolling restart of the containers running
       portal code. This is necessary after running migrations.
+  DisallowAllRobotsTxt:
+    Type: String
+    Description: set to true to have portal generate robots.txt that disallows all user
+      agents.  This option is checked first in the robots controller.
+    Default: false
+    AllowedValues:
+    - true
+    - false
   DynamicRobotsTxt:
     Type: String
     Description: set to true to have portal generate robots.txt otherwise the default
-      robots.txt will be used which denies all access
+      robots.txt will be used which denies all access UNLESS the DisallowAllRobotsTxt
+      is set to true as it is checked first.
     Default: false
     AllowedValues:
     - true
@@ -473,6 +482,8 @@ Resources:
           Value: !Ref GoogleClientSecret
         - Name: RESTART_TOGGLE
           Value: !Ref RestartToggle
+        - Name: DISALLOW_ALL_ROBOTS_TXT
+          Value: !Ref DisallowAllRobotsTxt
         - Name: DYNAMIC_ROBOTS_TXT
           Value: !Ref DynamicRobotsTxt
         - Name: CC_PORTAL_VERSION


### PR DESCRIPTION
This sets the value of the DISALLOW_ALL_ROBOTS_TXT environment variable that rigse uses to check if the robots.txt should emit rules to disallow all user agents.