### PR TITLE
update distributions with custom header

### DIFF
--- a/s3-cloudfront-scripts/README.md
+++ b/s3-cloudfront-scripts/README.md
@@ -64,13 +64,13 @@ Generate a `behaviors.csv` with information about the behaviors of all of the Cl
 
 ## cf-behavior-list (update enabled)
 
-At the end of `cf-behavior-list.mjs` are a 2 sections you can uncomment to update the distributions. The first was used to update all behaviors using public S3 buckets so they would use the S3-CORS cache policy. The second was used to update all origins pointing at public S3 buckets so they'd have a custom header of `Origin: https://concord.org`
+At the end of `cf-behavior-list.mjs` are two sections you can uncomment to update the distributions. The first was used to update all behaviors using public S3 buckets so they would use the S3-CORS cache policy. The second was used to update all origins pointing at public S3 buckets so they'd have a custom header of `Origin: https://concord.org`
 
-These sections looks for distributions meeting the certain criteria. Then for all matching distributions are passed to `updateDistributions` along with an option `modifyBehavior` and `modifyOrigin` function.
+These sections looks for distributions meeting certain criteria. Then all matching distributions are passed to `updateDistributions` along with an option `modifyBehavior` and `modifyOrigin` function.
 
 The update code is written to be modular so you can use these sections as a guide and add your own code for updating all of the distributions. 
 
-It is useful to test these modification with a single distribution before applying the changes to all distributions. See the test-update-behavior for that.
+It is useful to test these modifications with a single distribution before applying the changes to all distributions. See the test-update-behavior for that.
 
 ### Cache policy update details
 For the first cache policy update section, the distribution has to have at least one behavior that has all of the following properties:
@@ -83,7 +83,7 @@ Each matching distribution has each of behavior that meets the criteria above up
 ### Custom Header Update details
 For this section, we look for distributions that don't already have a custom header of Origin, and that have a bucket origin that has a public or public-custom-cors tag.
 
-Then we update each matching origin with the new custom header. There are some distributions that have multiple origins, so we need to check which origins need update in additional to figuring out which distributions need updating.
+Then we update each matching origin with the new custom header. There are some distributions that have multiple origins, so we need to check which origins need updating in addition to figuring out which distributions need updating.
 
 
 ## test-update-behavior

--- a/s3-cloudfront-scripts/README.md
+++ b/s3-cloudfront-scripts/README.md
@@ -52,6 +52,7 @@ Generate a `behaviors.csv` with information about the behaviors of all of the Cl
 - **PathPattern:** path pattern of the behavior, if this is the default behavior it will be blank
 - **OriginDomainName:** domain name of the origin associated with the behavior
 - **OriginPath:** path of the origin associated with the behavior
+- **OriginCustomHeaders:** any custom headers added to the distribution's Origin
 - **BucketName:** name of the bucket, this is computed from the domain of the origin, blank if it isn't a bucket
 - **BucketType:** BucketType tag of the bucket. blank if the behavior isn't associated with a bucket, or `error fetching` if an error happened when requesting the bucket tags
 - **ViewerProtocolPolicy:** how the behavior handles http requests
@@ -63,18 +64,27 @@ Generate a `behaviors.csv` with information about the behaviors of all of the Cl
 
 ## cf-behavior-list (update enabled)
 
-If you uncomment the last line in the `cf-behavior-list.mjs` file then the script will also update the distributions. This was used to update all behaviors using public S3 buckets so they would use the S3-CORS cache policy.
+At the end of `cf-behavior-list.mjs` are a 2 sections you can uncomment to update the distributions. The first was used to update all behaviors using public S3 buckets so they would use the S3-CORS cache policy. The second was used to update all origins pointing at public S3 buckets so they'd have a custom header of `Origin: https://concord.org`
 
-The update script part of the script looks for distributions meeting the following criteria. It has to have at least one behavior that has all of the following properties:
+These sections looks for distributions meeting the certain criteria. Then for all matching distributions are passed to `updateDistributions` along with an option `modifyBehavior` and `modifyOrigin` function.
+
+The update code is written to be modular so you can use these sections as a guide and add your own code for updating all of the distributions. 
+
+It is useful to test these modification with a single distribution before applying the changes to all distributions. See the test-update-behavior for that.
+
+### Cache policy update details
+For the first cache policy update section, the distribution has to have at least one behavior that has all of the following properties:
 - has a bucket origin (see the BucketName column above)
 - the bucket origin has a BucketType tag of 'public' or 'public-custom-cors'
 - the behavior doesn't already have a CachePolicyId of one of the two S3-CORS cache policies
 
-Each matching distribution has each of behavior that meets the criteria above updated to usse the S3-CORS cache policy. Cache Policies can only be associated with 100 distributions. So the script works with both the S3-CORS and S3-CORS-1 policies.
+Each matching distribution has each of behavior that meets the criteria above updated to use the S3-CORS cache policy. Cache Policies can only be associated with 100 distributions. So the script works with both the S3-CORS and S3-CORS-1 policies.
 
-The update code is written to be modular so you can replace the `modifyBehavior` function to look for different conditions and/or update the behavior differently. But note that that thre is a separate filter to figure out which distributions need updating, so that filter needs to be updated too.
+### Custom Header Update details
+For this section, we look for distributions that don't already have a custom header of Origin, and that have a bucket origin that has a public or public-custom-cors tag.
 
-It is useful to test these modification with a single distribution before applying the changes to all distributions. See the test-udpate-behavior for that.
+Then we update each matching origin with the new custom header. There are some distributions that have multiple origins, so we need to check which origins need update in additional to figuring out which distributions need updating.
+
 
 ## test-update-behavior
 

--- a/s3-cloudfront-scripts/package-lock.json
+++ b/s3-cloudfront-scripts/package-lock.json
@@ -1,8 +1,155 @@
 {
   "name": "cloud-formation-scripts",
   "version": "1.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "cloud-formation-scripts",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "aws-sdk": "^2.892.0",
+        "csv-writer": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=14.8.0"
+      }
+    },
+    "node_modules/aws-sdk": {
+      "version": "2.892.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.892.0.tgz",
+      "integrity": "sha512-OOXJ15AnJJMHZYXJQVy22Wjnp5GrZCfvCxmoZuXdsLNs8M+BL4mfBqma82+UkM2NhJgLYuAhDfvFUBob6VGIWw==",
+      "dependencies": {
+        "buffer": "4.9.2",
+        "events": "1.1.1",
+        "ieee754": "1.1.13",
+        "jmespath": "0.15.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "uuid": "3.3.2",
+        "xml2js": "0.4.19"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/buffer": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      }
+    },
+    "node_modules/csv-writer": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/csv-writer/-/csv-writer-1.6.0.tgz",
+      "integrity": "sha512-NOx7YDFWEsM/fTRAJjRpPp8t+MKRVvniAg9wQlUKx20MFrPs73WLJhFf5iteqrxNYnsy924K3Iroh3yNHeYd2g=="
+    },
+    "node_modules/events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "node_modules/jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+    },
+    "node_modules/querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
+    "node_modules/sax": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
+    },
+    "node_modules/url": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+      "dependencies": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "bin": {
+        "uuid": "bin/uuid"
+      }
+    },
+    "node_modules/xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
+      "engines": {
+        "node": ">=4.0"
+      }
+    }
+  },
   "dependencies": {
     "aws-sdk": {
       "version": "2.892.0",

--- a/s3-cloudfront-scripts/test-update-behavior.mjs
+++ b/s3-cloudfront-scripts/test-update-behavior.mjs
@@ -19,4 +19,20 @@ function modifyBehavior(distribution, behavior) {
   return true;
 }
 
-await updateDistributions(cloudfront, ["E3FXU5FXPVO7AK"], modifyBehavior);
+function modifyOrigin(origin) {
+  const customCorsOriginHeader = origin.CustomHeaders.Items
+    .find(header => header.HeaderName === "Origin");
+  if (customCorsOriginHeader) {
+    console.log(`Origin already has custom Origin header of ${customCorsOriginHeader.HeaderValue}`);
+    return false;
+  } else {
+    origin.CustomHeaders.Items.push({
+      HeaderName: "Origin",
+      HeaderValue: "https://concord.org"
+    })
+    origin.CustomHeaders.Quantity = origin.CustomHeaders.Items.length;
+    return true;
+  }
+}
+
+await updateDistributions(cloudfront, ["E3FXU5FXPVO7AK"], null, modifyOrigin);


### PR DESCRIPTION
This code has already been run on the production account. It is useful to check in and review so other developers know these scripts exist for when we have to change the buckets or distributions again.

More information about Buckets, Distributions, and CORS can be found here: https://docs.google.com/document/d/1TJxY5hYMgetRj-YQn06YuichDQP9lQINELtrD7MyjT4/edit#

This PR addresses the "New issue not handled by current setup" paragraph. That document needs to be updated to reflect this change.

The specific change this code applies is to add a custom `Origin: https://concord.org` header to most of the Distribution Origins (2 different things called origin here). It isn't applied to every Distribution Origin though since some Origins point to servers not S3 buckets.