### PR TITLE
Use original CloudFront Authorization at Edge (Update to Node 16)

### DIFF
--- a/private-distribution.yml
+++ b/private-distribution.yml
@@ -185,7 +185,7 @@ Resources:
         #
         # So we should try switching to using their application in the
         # serverlessrepo instead of ours. 
-        ApplicationId: arn:aws:serverlessrepo:us-east-1:816253370536:applications/cloudfront-authorization-at-edge
+        ApplicationId: arn:aws:serverlessrepo:us-east-1:520945424137:applications/cloudfront-authorization-at-edge
         SemanticVersion: !Ref SemanticVersion
       Parameters:
         CreateCloudFrontDistribution: "false"

--- a/private-distribution.yml
+++ b/private-distribution.yml
@@ -172,19 +172,10 @@ Resources:
     Type: AWS::Serverless::Application
     Properties:
       Location:
-        # This application lives in the concordqa account and it references
-        # content in a concordqa bucket.
-        #
-        # The application was forked from an AWS example that didn't support
-        # user pool groups at the time. This AWS example now supports groups.
-        # Additionally the AWS example always built a large react app just as a
-        # demo. This long build was causing problems so it was removed from our
-        # fork. The updated AWS example has an option to only deploy a simple
-        # static index.html file instead. Hopefully using that option would fix
-        # things for us. 
-        #
-        # So we should try switching to using their application in the
-        # serverlessrepo instead of ours. 
+        # We initially used a customized version of the AWS app:
+        # ApplicationId: arn:aws:serverlessrepo:us-east-1:816253370536:applications/cloudfront-authorization-at-edge
+        # https://github.com/concord-consortium/cloudfront-authorization-at-edge
+        # Our customizations were merged upstream, so we now use the official app.
         ApplicationId: arn:aws:serverlessrepo:us-east-1:520945424137:applications/cloudfront-authorization-at-edge
         SemanticVersion: !Ref SemanticVersion
       Parameters:


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/183393698

[#183393698]

While updating the AWS Lambda functions that provide authorization for CloudFront sites to use Node 16, we're also updating them to use the original  CloudFront Authorization at Edge serverless app instead of our own customized version. The original has been updated with the changes we needed thanks to @scytacki.