### PR TITLE
Add fargate/guide-server.yml used to create Geniventure ITS server stack

### DIFF
--- a/fargate/guide-server.yml
+++ b/fargate/guide-server.yml
@@ -1,0 +1,309 @@
+# Geniventure ITS Server
+# adapted from https://github.com/nathanpeck/aws-cloudformation-fargate/
+
+# All the values for secret parameters can be found in CC 1Password in a secure note named:
+# "Geniventure ITS Secret ENV variables / Cloud Formation template parameter values"
+
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Deploy guide-server on AWS Fargate, hosted in a public subnet, and accessible via a public load balancer.
+Parameters:
+  StackName:
+    Type: String
+    Default: fargate-public-network
+    Description: The name of the parent Fargate networking stack that you created. Necessary
+                 to locate and reference resources created by that stack.
+  ServiceName:
+    Type: String
+    Default: guide-server
+    Description: A name for the service
+  ImageUrl:
+    Type: String
+    Default: concordconsortium/guide-server:latest
+    Description: The url of a docker image that contains the application process that
+                 will handle the traffic for this service
+  ContainerPort:
+    Type: Number
+    Default: 3000
+    Description: What port number the application inside the docker container is binding to
+  ContainerCpu:
+    Type: Number
+    Default: 512
+    Description: How much CPU to give the container. 1024 is 1 CPU
+  ContainerMemory:
+    Type: Number
+    Default: 1024
+    Description: How much memory in megabytes to give the container
+  Path:
+    Type: String
+    Default: "/guide-server*"
+    Description: A path on the public load balancer that this service
+                 should be connected to. This should NOT be *.
+  PriorityForPath:
+    Type: Number
+    Default: 9
+    Description: The priority for the path routing rule added to the load balancer.
+                 This only applies if your have multiple services which have been
+                 assigned to different paths on the load balancer.
+  PriorityForHostname:
+    Type: Number
+    Default: 9
+    Description: The priority for the hostname routing rule added to the load balancer.
+                 This only applies if your have multiple services which have been
+                 assigned to different paths on the load balancer.
+  DesiredCount:
+    Type: Number
+    Default: 2
+    Description: How many copies of the service task to run
+  Subdomain:
+    Type: String
+    Default: guide-server
+    Description: The sub-domain to add to route (not apps) Route53 DNS record
+  GuideEnvConfigured:
+    Type: String
+    Default: true
+    Description: Deployment configured using env variables / CloudFormation parameters
+  BasePath:
+    Type: String
+    Default: /guide-server/
+    Description: ITS server base path
+  DbUri:
+    Type: String
+    Description: MongoDB URI
+  SessionSecret:
+    Type: String
+    Description: Session secret
+  FirebaseDbUrl:
+    Type: String
+    Description: Firebase configuration for updating Geniventure dashboard
+  FirebaseCredential:
+    Type: String
+    Description: Firebase configuration for updating Geniventure dashboard
+  GoogleId:
+    Type: String
+    Description: Auth Provider Configuration for GUIDE ITS Admin UI
+  GoogleSecret:
+    Type: String
+    Description: Auth Provider Configuration for GUIDE ITS Admin UI
+  SendgridUser:
+    Type: String
+    Description: Password reset e-mail sender
+  SendgridPassword:
+    Type: String
+    Description: Password reset e-mail sender
+
+Resources:
+  # The task definition. This is a simple metadata description of what
+  # container to run, and what resource requirements it has.
+  TaskDefinition:
+    Type: AWS::ECS::TaskDefinition
+    DependsOn: LogGroup
+    Properties:
+      Family: !Ref 'ServiceName'
+      Cpu: !Ref 'ContainerCpu'
+      Memory: !Ref 'ContainerMemory'
+      NetworkMode: awsvpc
+      RequiresCompatibilities:
+        - FARGATE
+      ExecutionRoleArn:
+        Fn::ImportValue:
+          !Join [':', [!Ref 'StackName', 'ECSTaskExecutionRole']]
+      ContainerDefinitions:
+        - Name: !Ref 'ServiceName'
+          Cpu: !Ref 'ContainerCpu'
+          Memory: !Ref 'ContainerMemory'
+          Image: !Ref 'ImageUrl'
+          PortMappings:
+            - ContainerPort: !Ref 'ContainerPort'
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-region: !Ref AWS::Region
+              awslogs-group: !Ref LogGroup
+              awslogs-stream-prefix: ecs
+          Environment:
+            - Name: GUIDE_ENV_CONFIGURED
+              Value: !Ref GuideEnvConfigured
+            - Name: BASE_PATH
+              Value: !Ref BasePath
+            - Name: DB_URI
+              Value: !Ref DbUri
+            - Name: SESSION_SECRET
+              Value: !Ref SessionSecret
+            - Name: FIREBASE_DB_URL
+              Value: !Ref FirebaseDbUrl
+            - Name: FIREBASE_CREDENTIAL
+              Value: !Ref FirebaseCredential
+            - Name: GOOGLE_ID
+              Value: !Ref GoogleId
+            - Name: GOOGLE_SECRET
+              Value: !Ref GoogleSecret
+            - Name: SENDGRID_USER
+              Value: !Ref SendgridUser
+            - Name: SENDGRID_PASSWORD
+              Value: !Ref SendgridPassword
+
+  LogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Join ['', [/ecs/, !Ref 'ServiceName']]
+
+  # The service. The service is a resource which allows you to run multiple
+  # copies of a type of task, and gather up their logs and metrics, as well
+  # as monitor the number of running tasks and replace any that have crashed
+  Service:
+    Type: AWS::ECS::Service
+    DependsOn:
+      - LoadBalancerRule80Path
+      - LoadBalancerRule443Path
+      - LoadBalancerRule80Host
+      - LoadBalancerRule443Host
+    Properties:
+      ServiceName: !Ref 'ServiceName'
+      Cluster:
+        Fn::ImportValue:
+          !Join [':', [!Ref 'StackName', 'ClusterName']]
+      LaunchType: FARGATE
+      DeploymentConfiguration:
+        MaximumPercent: 200
+        MinimumHealthyPercent: 75
+      DesiredCount: !Ref 'DesiredCount'
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          AssignPublicIp: ENABLED
+          SecurityGroups:
+            - Fn::ImportValue:
+                !Join [':', [!Ref 'StackName', 'FargateContainerSecurityGroup']]
+            - !Ref ServiceSecurityGroup
+          Subnets:
+            - Fn::ImportValue:
+                !Join [':', [!Ref 'StackName', 'PublicSubnetOne']]
+            - Fn::ImportValue:
+                !Join [':', [!Ref 'StackName', 'PublicSubnetTwo']]
+      TaskDefinition: !Ref 'TaskDefinition'
+      LoadBalancers:
+        - ContainerName: !Ref 'ServiceName'
+          ContainerPort: !Ref 'ContainerPort'
+          TargetGroupArn: !Ref 'TargetGroup'
+
+  ServiceSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Log puller ECS service security group
+      VpcId:
+        Fn::ImportValue:
+          !Join [':', [!Ref 'StackName', 'VPCId']]
+
+  # A target group. This is used for keeping track of all the tasks, and
+  # what IP addresses / port numbers they have. You can query it yourself,
+  # to use the addresses yourself, but most often this target group is just
+  # connected to an application load balancer, or network load balancer, so
+  # it can automatically distribute traffic across all the targets.
+  TargetGroup:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      HealthCheckIntervalSeconds: 6
+      HealthCheckPath: /health
+      HealthCheckProtocol: HTTP
+      HealthCheckTimeoutSeconds: 5
+      HealthyThresholdCount: 2
+      TargetType: ip
+      Name: !Ref 'ServiceName'
+      Port: !Ref 'ContainerPort'
+      Protocol: HTTP
+      UnhealthyThresholdCount: 2
+      # Stickiness is necessary for WebSocket connections to work
+      TargetGroupAttributes:
+        - Key: stickiness.enabled
+          Value: true
+        - Key: stickiness.type
+          Value: lb_cookie
+      VpcId:
+        Fn::ImportValue:
+          !Join [':', [!Ref 'StackName', 'VPCId']]
+
+  LoadBalancerRule80Path:
+    Type: AWS::ElasticLoadBalancingV2::ListenerRule
+    Properties:
+      Actions:
+        - TargetGroupArn: !Ref 'TargetGroup'
+          Type: 'forward'
+      Conditions:
+        - Field: path-pattern
+          Values: [!Ref 'Path']
+      ListenerArn:
+        Fn::ImportValue:
+          !Join [':', [!Ref 'StackName', 'PublicListener80']]
+      Priority: !Ref 'PriorityForPath'
+  LoadBalancerRule443Path:
+    Type: AWS::ElasticLoadBalancingV2::ListenerRule
+    Properties:
+      Actions:
+        - TargetGroupArn: !Ref 'TargetGroup'
+          Type: 'forward'
+      Conditions:
+        - Field: path-pattern
+          Values: [!Ref 'Path']
+      ListenerArn:
+        Fn::ImportValue:
+          !Join [':', [!Ref 'StackName', 'PublicListener443']]
+      Priority: !Ref 'PriorityForPath'
+
+  LoadBalancerRule80Host:
+    Type: AWS::ElasticLoadBalancingV2::ListenerRule
+    Properties:
+      Actions:
+        - TargetGroupArn: !Ref 'TargetGroup'
+          Type: 'forward'
+      Conditions:
+        - Field: host-header
+          Values:
+            - Fn::Join:
+                - ''
+                - - !Ref Subdomain
+                  - '.'
+                  - Fn::ImportValue: !Join [':', [!Ref 'StackName', 'HostedZoneName']]
+      ListenerArn:
+        Fn::ImportValue:
+          !Join [':', [!Ref 'StackName', 'PublicListener80']]
+      Priority: !Ref 'PriorityForHostname'
+  LoadBalancerRule443Host:
+    Type: AWS::ElasticLoadBalancingV2::ListenerRule
+    Properties:
+      Actions:
+        - TargetGroupArn: !Ref 'TargetGroup'
+          Type: 'forward'
+      Conditions:
+        - Field: host-header
+          Values:
+            - Fn::Join:
+                - ''
+                - - !Ref Subdomain
+                  - '.'
+                  - Fn::ImportValue: !Join [':', [!Ref 'StackName', 'HostedZoneName']]
+      ListenerArn:
+        Fn::ImportValue:
+          !Join [':', [!Ref 'StackName', 'PublicListener443']]
+      Priority: !Ref 'PriorityForHostname'
+
+  DNSRecord:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      HostedZoneName:
+        Fn::Join:
+          - ''
+          - - Fn::ImportValue: !Join [':', [!Ref 'StackName', 'HostedZoneName']]
+            - '.'
+      Name:
+        Fn::Join:
+          - ''
+          - - !Ref Subdomain
+            - '.'
+            - Fn::ImportValue: !Join [':', [!Ref 'StackName', 'HostedZoneName']]
+      Type: A
+      AliasTarget:
+        DNSName:
+          Fn::ImportValue: !Join [':', [!Ref 'StackName', 'LoadBalancerDNSName']]
+        HostedZoneId:
+          Fn::ImportValue: !Join [':', [!Ref 'StackName', 'LoadBalancerCanonicalHostedZoneID']]
+
+


### PR DESCRIPTION
[[#184539865]](https://www.pivotaltracker.com/story/show/184539865)

This PR adds a template used to spin up Geniventure ITS server using AWS Fargate. It's primarily based on the log-puller template. However:

- It assumes that the server implements an explicit health-check path `/health` that returns 200 OK.
- `TargetGroup` stickiness parameter is enabled. This is necessary for WebSocket connections to work.

All the secrets / env variables / template params can be found in CC 1password in a secure note named "Geniventure ITS Secret ENV variables / Cloud Formation template parameter values".
