### PR TITLE
DEV-162: Disable API Gateway execution logs on log-ingester

### DIFF
--- a/log-ingester.json
+++ b/log-ingester.json
@@ -291,9 +291,9 @@
       "Properties": {
         "DeploymentId": {"Ref": "LogAPIGatewayDeployment"},
         "MethodSettings": [{
-          "DataTraceEnabled": true,
+          "DataTraceEnabled": false,
           "HttpMethod": "*",
-          "LoggingLevel": "INFO",
+          "LoggingLevel": "OFF",
           "ResourcePath": "/*"
         }],
         "RestApiId": {"Ref": "LogAPIGateway"},


### PR DESCRIPTION
## What
Disable the verbose API Gateway **execution logs** on the log-ingester stack's API Gateway stage. Sets `LoggingLevel` `INFO`→`OFF` and `DataTraceEnabled` `true`→`false` in `LogAPIGatewayStage.MethodSettings`.

## Why
`DataTraceEnabled: true` logged full request/response bodies on what is a log-ingestion endpoint — high volume and potentially sensitive. Access logs are unaffected (none were ever configured; `AccessLogSetting` remains absent / `accessLogSettings: null`).

## Testing
Deployed to the QA account (`log-ingester-qa`) and verified the live `latest` stage:
- `loggingLevel: OFF`
- `dataTraceEnabled: false`
- `accessLogSettings: null` (unchanged)
- Stack `UPDATE_COMPLETE`

Production (`log-ingester-prod`) is **not** touched by this PR; it can be deployed separately after merge.

[DEV-162](https://concord-consortium.atlassian.net/browse/DEV-162)

[DEV-162]: https://concord-consortium.atlassian.net/browse/DEV-162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ