### PR TITLE
chore: reconcile report-server.yml with deployed config

### DIFF
--- a/fargate/report-server.yml
+++ b/fargate/report-server.yml
@@ -118,6 +118,11 @@ Parameters:
     AllowedValues: ["false", "true"]
     Default: "false"
     Description: Set to true to disable the stats server from periodically querying the portals
+  DisableExportsSweep:
+    Type: String
+    AllowedValues: ["false", "true"]
+    Default: "false"
+    Description: Set to true to disable the periodic export_scratch sweep GenServer
   ReportServerRDSSecurityGroupId:
     Type: AWS::EC2::SecurityGroup::Id
     Description: ID of RDS security group for report server database
@@ -208,6 +213,8 @@ Resources:
               Value: !Ref NgssDB
             - Name: DISABLE_STATS_SERVER
               Value: !Ref DisableStatsServer
+            - Name: DISABLE_EXPORTS_SWEEP
+              Value: !Ref DisableExportsSweep
             - Name: DATABASE_URL
               Value: !Ref DatabaseUrl
             - Name: ATHENA_REPORT_BUCKET

--- a/fargate/report-server.yml
+++ b/fargate/report-server.yml
@@ -36,14 +36,14 @@ Parameters:
                  should be connected to. This should NOT be *.
   PriorityForPath:
     Type: Number
-    Default: 10
+    Default: 75
     Description: The priority for the path routing rule added to the load balancer.
                  This only applies if your have multiple services which have been
                  assigned to different paths on the load balancer.   This CANNOT be the
                  same value as PriorityForHostname.
   PriorityForHostname:
     Type: Number
-    Default: 11
+    Default: 76
     Description: The priority for the hostname routing rule added to the load balancer.
                  This only applies if your have multiple services which have been
                  assigned to different paths on the load balancer.  This CANNOT be the
@@ -97,6 +97,52 @@ Parameters:
     Type: String
     Default: transcripts
     Description: The folder under which the audio transcripts are stored.
+  LearnStagingDB:
+    Type: String
+    Default: mysql://<username>:<password>@<host>:<port>
+    Description: The connection string to learn staging portal
+  LearnDB:
+    Type: String
+    Default: mysql://<username>:<password>@<host>:<port>
+    Description: The connection string to learn portal
+  NgssDB:
+    Type: String
+    Default: mysql://<username>:<password>@<host>:<port>
+    Description: The connection string to NGSS portal
+  DatabaseUrl:
+    Type: String
+    Default: ecto://USER:PASS@HOST/DATABASE
+    Description: The connection string to report server database
+  DisableStatsServer:
+    Type: String
+    AllowedValues: ["false", "true"]
+    Default: "false"
+    Description: Set to true to disable the stats server from periodically querying the portals
+  ReportServerRDSSecurityGroupId:
+    Type: AWS::EC2::SecurityGroup::Id
+    Description: ID of RDS security group for report server database
+  NGSSRDSSecurityGroupId:
+    Type: AWS::EC2::SecurityGroup::Id
+    Description: ID of RDS security group for NGSS database
+  AthenaReportBucket:
+    Type: String
+    Default: "concord-report-data"
+    Description: S3 bucket for storing Athena workgroup reports
+  AthenaLogDbName:
+    Type: String
+    Default: "log_ingester_production"
+    Description: Name of Athena Log database (defined in AWS Glue)
+  HideUsernameHashSalt:
+    Type: String
+    Description: Salt to add to username hash when hiding usernames
+  ReportServiceFirebaseApp:
+    Type: String
+    Description: Firebase app name for report service used to generate class dashboard links
+    Default: "report-service-pro"
+  AthenaSourceKey:
+    Type: String
+    Description: Source key for report service data used by Athena reports
+    Default: "authoring.concord.org"
 
 Resources:
 
@@ -151,6 +197,26 @@ Resources:
               Value: !Ref JobsFolder
             - Name: TRANSCRIPTS_FOLDER
               Value: !Ref TranscriptsFolder
+            - Name: LEARN_PORTAL_STAGING_CONCORD_ORG_DB
+              Value: !Ref LearnStagingDB
+            - Name: LEARN_CONCORD_ORG_DB
+              Value: !Ref LearnDB
+            - Name: NGSS_ASSESSMENT_PORTAL_CONCORD_ORG_DB
+              Value: !Ref NgssDB
+            - Name: DISABLE_STATS_SERVER
+              Value: !Ref DisableStatsServer
+            - Name: DATABASE_URL
+              Value: !Ref DatabaseUrl
+            - Name: ATHENA_REPORT_BUCKET
+              Value: !Ref AthenaReportBucket
+            - Name: HIDE_USERNAME_HASH_SALT
+              Value: !Ref HideUsernameHashSalt
+            - Name: ATHENA_LOG_DB_NAME
+              Value: !Ref AthenaLogDbName
+            - Name: REPORT_SERVICE_FIREBASE_APP
+              Value: !Ref ReportServiceFirebaseApp
+            - Name: ATHENA_SOURCE_KEY
+              Value: !Ref AthenaSourceKey
             - Name: PHX_HOST
               Value:
                 Fn::Join:
@@ -176,6 +242,7 @@ Resources:
       - LoadBalancerRule443Host
     Properties:
       ServiceName: !Ref 'ServiceName'
+       # EnableExecuteCommand: true
       Cluster:
         Fn::ImportValue:
           !Join [':', [!Ref 'StackName', 'ClusterName']]
@@ -209,6 +276,26 @@ Resources:
       VpcId:
         Fn::ImportValue:
           !Join [':', [!Ref 'StackName', 'VPCId']]
+
+  ServiceDBIngress:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      Description: Adds ECS service to Report Service RDS security group
+      GroupId: !Ref ReportServerRDSSecurityGroupId
+      IpProtocol: tcp
+      FromPort: 3306
+      ToPort: 3306
+      SourceSecurityGroupId: !Ref ServiceSecurityGroup
+
+  NGSSDBIngress:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      Description: Adds ECS service to NGSS RDS security group
+      GroupId: !Ref NGSSRDSSecurityGroupId
+      IpProtocol: tcp
+      FromPort: 3306
+      ToPort: 3306
+      SourceSecurityGroupId: !Ref ServiceSecurityGroup
 
   # A target group. This is used for keeping track of all the tasks, and
   # what IP addresses / port numbers they have. You can query it yourself,

--- a/fargate/report-server.yml
+++ b/fargate/report-server.yml
@@ -144,6 +144,9 @@ Parameters:
     Description: Source key for report service data used by Athena reports
     Default: "authoring.concord.org"
 
+Conditions:
+  UsesNGSS: !Not [!Equals [!Ref NGSSRDSSecurityGroupId, ""]]
+
 Resources:
 
   # The task definition. This is a simple metadata description of what
@@ -289,6 +292,7 @@ Resources:
 
   NGSSDBIngress:
     Type: AWS::EC2::SecurityGroupIngress
+    Condition: UsesNGSS
     Properties:
       Description: Adds ECS service to NGSS RDS security group
       GroupId: !Ref NGSSRDSSecurityGroupId


### PR DESCRIPTION
## Why

`fargate/report-server.yml` drives the `report-server` Elixir/Phoenix service on Fargate — deployed as **two stacks**: `report-service-qa` (staging, QA account) and `report-service-prod` (production account). The config that has actually been running was **never committed to `master`**: `master`'s copy of this template is missing `DATABASE_URL` and ~10 other environment variables (portal DB connection strings, Athena config, `HIDE_USERNAME_HASH_SALT`), plus the RDS security-group ingress wiring the running services depend on.

That hand-authored deployed config existed only in a local, never-pushed commit — `e8173f1` ("build: Update report-server config for v1.2.0", Dec 2024). This PR makes the repo reflect reality, then adds one new knob the running app has since grown.

## What this PR does

1. **Replays `e8173f1` onto current `master`** (commit 1). Adds the DB/Athena/portal parameters, the corresponding `Environment` variables, and the `ServiceDBIngress` / `NGSSDBIngress` security-group rules. `master`'s later addition of `REPORT_SERVICE_URL` is preserved (non-overlapping, no conflict).
2. **Reconciles against the live CloudFormation templates** (commit 2). Both deployed templates were pulled read-only via `get-template` and diffed against the replayed file.
3. **Adds a `DisableExportsSweep` parameter** (commit 3) — see below.

## Verification against deployed templates

The replayed file landed between the two deployed stacks:

| | `UsesNGSS` condition | `ReportServiceFirebaseApp` / `AthenaSourceKey` defaults |
|---|---|---|
| deployed **staging** (newer) | ✅ | ✅ |
| replayed `e8173f1` | ❌ | ✅ |
| deployed **prod** (older) | ❌ | ❌ |

The one real delta folded in: staging's **`UsesNGSS` condition**, which gates `NGSSDBIngress` on a non-empty `NGSSRDSSecurityGroupId` (making the NGSS RDS wiring optional). This was added after v1.2.0, when the **NGSS assessment portal was dropped from production dashboard stats** (report-service `7a47bce`, v1.8.3, May 2026). Both stacks currently pass a real NGSS security group, so the condition evaluates true in both — commit 2 makes the committed template **byte-match deployed staging** and stay **behaviorally identical to production** today. Production is simply on the older template shape and can converge later.

## New parameter: `DisableExportsSweep`

`runtime.exs` reads `DISABLE_EXPORTS_SWEEP` (report-service `ba3a6ed`, "export_scratch sweep GenServer", REPORT-76, 2026-07-15), but the template had no parameter for it — the periodic sweeper couldn't be toggled per stack. Added an optional `DisableExportsSweep` parameter mirroring the existing `DisableStatsServer` (`Default: "false"` preserves current behavior — sweep enabled) and wired it to the container env var. This is the **only** app-specific env var added since v1.2.0 that lacked a parameter (`ATHENA_SOURCE_KEY` and `REPORT_SERVICE_FIREBASE_APP` were already covered). It is additive and takes effect on next deploy; the deployed stacks don't set it yet.

## Env-var cross-check

Confirmed the reconciled `Environment` block supplies every var the prod runtime (`report-service/server/config/runtime.exs`) requires. The vars not supplied by the template (`PORT`, `POOL_SIZE`, `PORTAL_REPORT_URL`, `PHX_SERVER`, `DNS_CLUSTER_QUERY`, `ECTO_IPV6`, and the two commented-out `SOME_APP_SSL_*`) are all optional/defaulted in code — none are required (`fetch_env!`).

## Not changed / notes

- No AWS stacks were mutated — read-only `get-template` / `describe-stacks` only. This PR makes the repo match reality; it does not redeploy.
- All connection strings / keys / salts remain CloudFormation **Parameters** (no secret values committed).
- `NGSSRDSSecurityGroupId` is typed `AWS::EC2::SecurityGroup::Id`, so the "pass empty to disable NGSS" path isn't fully wired (CFN rejects empty for that type) — this mirrors the deployed staging template as-is and is left unchanged.
- `PORTAL_REPORT_URL` is intentionally not a parameter: it's a local-dev override for pointing at a specific portal-report branch or a portal-report running on localhost, with the production URL as the in-code default. No parameter needed.
